### PR TITLE
Silently ignore unknown permissions instead of throwing an IllegalArgumentException

### DIFF
--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -276,9 +276,10 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
                     if ((Boolean) e.getValue()) {
                         Permission p = Permission.fromId(e.getKey());
                         if (p == null) {
-                            throw new IllegalArgumentException("Unknown permission:\"" + e.getKey() + "\" set to \"" + e.getValue() +"\" for sid \"" + sid + "\"");
+                            LOGGER.log(Level.FINE, "Silently skip unknown permission \"{0}\" for sid:\"{1}\"", new Object[]{e.getKey(), sid});
+                        } else {
+                            gmas.add(p, sid);
                         }
-                        gmas.add(p,sid);
                     }
                 }
             }

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -91,7 +91,9 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
      */
     public void add(Permission p, String sid) {
         if (p==null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Permission can not be null for sid:" + sid);
+
+        LOGGER.log(Level.FINE, "Grant permission \"{0}\" to \"{1}\")", new Object[]{p, sid});
         Set<String> set = grantedPermissions.get(p);
         if(set==null)
             grantedPermissions.put(p,set = new HashSet<String>());
@@ -273,6 +275,9 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
                     }
                     if ((Boolean) e.getValue()) {
                         Permission p = Permission.fromId(e.getKey());
+                        if (p == null) {
+                            throw new IllegalArgumentException("Unknown permission:\"" + e.getKey() + "\" set to \"" + e.getValue() +"\" for sid \"" + sid + "\"");
+                        }
                         gmas.add(p,sid);
                     }
                 }


### PR DESCRIPTION
Better exception message if a permission does not exist.

The current message does not indicate which permission is unknown:

```
Caused by: java.lang.IllegalArgumentException
    at hudson.security.GlobalMatrixAuthorizationStrategy.add(GlobalMatrixAuthorizationStrategy.java:94)
    at hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl.newInstance(GlobalMatrixAuthorizationStrategy.java:276)
    at hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl.newInstance(GlobalMatrixAuthorizationStrategy.java:248)
```

New message

```
Caused by: java.lang.IllegalArgumentException: Unknown permission:"com.cloudbees.plugins.updatecenter.UpdateCenter.Configure" set to "true" for sid "configure_jenkins"
	at hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl.newInstance(GlobalMatrixAuthorizationStrategy.java:279)
	at hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl.newInstance(GlobalMatrixAuthorizationStrategy.java:250)
```