### PR TITLE
[FIXED JENKINS-29527] - AuthorizationMatrixProperty converter: Inheritance blocking may be passed incorrectly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+Strategy+Plugin</url>
     <properties>
       <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
-      <findbugs.failOnError>false</findbugs.failOnError>
+      <findbugs.failOnError>true</findbugs.failOnError>
     </properties>
     <licenses>
         <license>

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -306,9 +306,9 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
 				reader.moveDown();
 				reader.getValue(); // we used to use this but not any more.
 				reader.moveUp();
-				prop = reader.peekNextChild();
+				prop = reader.peekNextChild(); // We check the next field
 			}
-			else if ("blocksInheritance".equals(prop)) {
+			if ("blocksInheritance".equals(prop)) {
 			    reader.moveDown();
 			    as.setBlocksInheritance("true".equals(reader.getValue()));
 			    reader.moveUp();


### PR DESCRIPTION
It's a follow-up to #2 

If "useProjectSecurity" appears in the marshalled stream before "blocksInheritance", the second option may be ignored => the project may start taking inherited permissions. However, seems the code just iterates through fields => we should not use the else clause. The assigned "prop" variable is never used, so it's another clue of the bug

@reviewbybees @stephenc 