### PR TITLE
Allow checkName for property descriptor to be invoked from Items.

### DIFF
--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -194,7 +194,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
             return p.getEnabled() && p.isContainedBy(PermissionScope.ITEM);
         }
 
-        public FormValidation doCheckName(@AncestorInPath Job project, @QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckName(@AncestorInPath Item project, @QueryParameter String value) throws IOException, ServletException {
             return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value, project, Item.CONFIGURE);
         }
     }


### PR DESCRIPTION
In the event that an Item's view is acting as a proxy for the configuration of a project's AuthorizationMatrixProperty, it should be able to check the name on that view.

If the check fails, submitted configuration includes an extra permission field (```"q": ""```) which causes a class cast error because the value is expected to be ```true``` or ```false```.

I would prefer that this is a pre-requisite for an update I plan to push out for the Multi-Branch Project Plugin.  Currently I have this diff to hide the project-based matrix configuration on my Item's configuration page https://github.com/mjdetullio/multi-branch-project-plugin/commit/5601714af2fcca5d6115961f7ae1eddf29d8bc8b#diff-6a6195f00348ad67c3dff2fd8ed5e85dL47 but would like to remove it and support this auth strategy on my item.

I've also considered additional changes to make items configurable with the property using another interface but I feel like that would turn into just a hack if anything.