### PR TITLE
[JENKINS-31860] Restore return type to match API

### DIFF
--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -117,7 +117,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     @Override
-    public SidACL getRootACL() {
+    public ACL getRootACL() {
         return acl;
     }
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-31860

@reviewbybees 

I am not entirely happy with this approach as when we have one of the parent / child ACLs being non `SidACL` then the semantics of `Boolean hasPermission(Sid p, Permission permission)` may be subverted... IOW we have no way to differentiate between the Child ACL saying "`Boolean.FALSE`->no and don't check the parent" and the Child ACL saying "`null`->only if parent is ok"