### PR TITLE
Add cloudbees-folder dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.535</version>
+        <version>2.3</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>1.3-SNAPSHOT</version>
@@ -12,13 +12,12 @@
     <description>Offers matrix-based security authorization strategies (global and per-project).</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+Strategy+Plugin</url>
     <properties>
-      <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
-      <findbugs.failOnError>true</findbugs.failOnError>
+      <jenkins.version>1.625.3</jenkins.version> <!-- must have a65d007 -->
     </properties>
     <licenses>
         <license>
             <name>MIT</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
     <scm>
@@ -28,35 +27,18 @@
     </scm>
     <dependencies>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.0</version>
-            <scope>provided</scope>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <version>5.2-SNAPSHOT</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1.24</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs-maven-plugin.version}</version>
-                <configuration>
-                    <xmlOutput>true</xmlOutput>
-                    <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-                    <failOnError>${findbugs.failOnError}</failOnError>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>run-findbugs</id>
-                        <phase>verify</phase> 
-                        <goals>
-                            <goal>check</goal> 
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>5.2-SNAPSHOT</version>
+            <version>5.2</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -1,0 +1,283 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Yahoo! Inc., Peter Hayes, Tom Huybrechts
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.hudson.plugins.folder.properties;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor.FormException;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import hudson.security.PermissionScope;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import hudson.security.SidACL;
+import hudson.util.FormValidation;
+import hudson.util.RobustReflectionConverter;
+import net.sf.json.JSONObject;
+import org.acegisecurity.acls.sid.Sid;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+
+/**
+ * Holds ACL for {@link ProjectMatrixAuthorizationStrategy}.
+ */
+public class AuthorizationMatrixProperty extends AbstractFolderProperty<AbstractFolder<?>> {
+
+    private transient SidACL acl = new AclImpl();
+
+    /**
+     * List up all permissions that are granted.
+     *
+     * Strings are either the granted authority or the principal, which is not
+     * distinguished.
+     */
+    private final Map<Permission, Set<String>> grantedPermissions = new HashMap<Permission, Set<String>>();
+
+    private Set<String> sids = new HashSet<String>();
+
+    protected AuthorizationMatrixProperty() {
+    }
+
+    public AuthorizationMatrixProperty(Map<Permission,? extends Set<String>> grantedPermissions) {
+        // do a deep copy to be safe
+        for (Entry<Permission,? extends Set<String>> e : grantedPermissions.entrySet())
+            this.grantedPermissions.put(e.getKey(),new HashSet<String>(e.getValue()));
+    }
+
+    public Set<String> getGroups() {
+        return sids;
+    }
+
+    /**
+     * Returns all SIDs configured in this matrix, minus "anonymous"
+     *
+     * @return Always non-null.
+     */
+    public List<String> getAllSIDs() {
+        Set<String> r = new HashSet<String>();
+        for (Set<String> set : grantedPermissions.values())
+            r.addAll(set);
+        r.remove("anonymous");
+
+        String[] data = r.toArray(new String[r.size()]);
+        Arrays.sort(data);
+        return Arrays.asList(data);
+    }
+
+    /**
+     * Returns all the (Permission,sid) pairs that are granted, in the multi-map form.
+     *
+     * @return
+     *      read-only. never null.
+     */
+    public Map<Permission,Set<String>> getGrantedPermissions() {
+        return Collections.unmodifiableMap(grantedPermissions);
+    }
+
+    /**
+     * Adds to {@link #grantedPermissions}. Use of this method should be limited
+     * during construction, as this object itself is considered immutable once
+     * populated.
+     */
+    protected void add(Permission p, String sid) {
+        Set<String> set = grantedPermissions.get(p);
+        if (set == null)
+            grantedPermissions.put(p, set = new HashSet<String>());
+        set.add(sid);
+        sids.add(sid);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
+        @Override
+        public AbstractFolderProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            formData = formData.getJSONObject("useProjectSecurity");
+            if (formData.isNullObject())
+                return null;
+
+            AuthorizationMatrixProperty amp = new AuthorizationMatrixProperty();
+            for (Map.Entry<String, Object> r : (Set<Map.Entry<String, Object>>) formData.getJSONObject("data").entrySet()) {
+                String sid = r.getKey();
+                if (r.getValue() instanceof JSONObject) {
+                    for (Map.Entry<String, Boolean> e : (Set<Map.Entry<String, Boolean>>) ((JSONObject) r
+                            .getValue()).entrySet()) {
+                        if (e.getValue()) {
+                            Permission p = Permission.fromId(e.getKey());
+                            amp.add(p, sid);
+                        }
+                    }
+                }
+            }
+            return amp;
+        }
+
+        @SuppressWarnings("rawtypes") // erasure
+        @Override
+        public boolean isApplicable(Class<? extends AbstractFolder> containerType) {
+            // only applicable when ProjectMatrixAuthorizationStrategy is in charge
+            try {
+                return Jenkins.getActiveInstance().getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy;
+            } catch (NoClassDefFoundError x) { // after matrix-auth split?
+                return false;
+            }
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Authorization Matrix";
+        }
+
+        public List<PermissionGroup> getAllGroups() {
+            List<PermissionGroup> groups = new ArrayList<PermissionGroup>();
+            for (PermissionGroup g : PermissionGroup.getAll()) {
+                if (g.hasPermissionContainedBy(PermissionScope.ITEM_GROUP)) {
+                    groups.add(g);
+                }
+            }
+            return groups;
+        }
+
+        public boolean showPermission(Permission p) {
+            return p.getEnabled() && p.isContainedBy(PermissionScope.ITEM_GROUP);
+        }
+
+        public FormValidation doCheckName(@AncestorInPath AbstractFolder<?> folder, @QueryParameter String value) throws IOException, ServletException {
+            return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value, folder, AbstractProject.CONFIGURE);
+        }
+    }
+
+    private final class AclImpl extends SidACL {
+        @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "NP_BOOLEAN_RETURN_NULL",
+                justification = "Because that is the way this SPI works")
+        protected Boolean hasPermission(Sid sid, Permission p) {
+            if (AuthorizationMatrixProperty.this.hasPermission(toString(sid),p))
+                return true;
+            return null;
+        }
+    }
+
+    public SidACL getACL() {
+        return acl;
+    }
+
+    /**
+     * Checks if the given SID has the given permission.
+     */
+    public boolean hasPermission(String sid, Permission p) {
+        for (; p != null; p = p.impliedBy) {
+            Set<String> set = grantedPermissions.get(p);
+            if (set != null && set.contains(sid))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the permission is explicitly given, instead of implied through {@link Permission#impliedBy}.
+     */
+    public boolean hasExplicitPermission(String sid, Permission p) {
+        Set<String> set = grantedPermissions.get(p);
+        return set != null && set.contains(sid);
+    }
+
+    /**
+     * Works like {@link #add(Permission, String)} but takes both parameters
+     * from a single string of the form <tt>PERMISSIONID:sid</tt>
+     */
+    private void add(String shortForm) {
+        int idx = shortForm.indexOf(':');
+        Permission p = Permission.fromId(shortForm.substring(0, idx));
+        if (p==null)
+            throw new IllegalArgumentException("Failed to parse '"+shortForm+"' --- no such permission");
+        add(p, shortForm.substring(idx + 1));
+    }
+
+    /**
+     * Persist {@link ProjectMatrixAuthorizationStrategy} as a list of IDs that
+     * represent {@link ProjectMatrixAuthorizationStrategy#grantedPermissions}.
+     */
+    public static final class ConverterImpl implements Converter {
+        public boolean canConvert(Class type) {
+            return type == AuthorizationMatrixProperty.class;
+        }
+
+        public void marshal(Object source, HierarchicalStreamWriter writer,
+                MarshallingContext context) {
+            AuthorizationMatrixProperty amp = (AuthorizationMatrixProperty) source;
+
+            for (Entry<Permission, Set<String>> e : amp.grantedPermissions
+                    .entrySet()) {
+                String p = e.getKey().getId();
+                for (String sid : e.getValue()) {
+                    writer.startNode("permission");
+                    writer.setValue(p + ':' + sid);
+                    writer.endNode();
+                }
+            }
+        }
+
+        public Object unmarshal(HierarchicalStreamReader reader,
+                final UnmarshallingContext context) {
+            AuthorizationMatrixProperty as = new AuthorizationMatrixProperty();
+
+            while (reader.hasMoreChildren()) {
+                reader.moveDown();
+                try {
+                    as.add(reader.getValue());
+                } catch (IllegalArgumentException ex) {
+                     Logger.getLogger(AuthorizationMatrixProperty.class.getName())
+                           .log(Level.WARNING,"Skipping a non-existent permission",ex);
+                     RobustReflectionConverter.addErrorInContext(context, ex);
+                }
+                reader.moveUp();
+            }
+
+            return as;
+        }
+    }
+}

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -173,7 +173,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
 		@Override
 		public boolean isApplicable(Class<? extends Job> jobType) {
             // only applicable when ProjectMatrixAuthorizationStrategy is in charge
-            return Jenkins.getInstance().getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy;
+            return Jenkins.getActiveInstance().getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy;
 		}
 
 		@Override

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -132,7 +132,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
      */
     /*package*/ static boolean migrateHudson2324(Map<Permission,Set<String>> grantedPermissions) {
         boolean result = false;
-        if(Jenkins.getInstance().isUpgradedFromBefore(new VersionNumber("1.300.*"))) {
+        if(Jenkins.getActiveInstance().isUpgradedFromBefore(new VersionNumber("1.300.*"))) {
             Set<String> f = grantedPermissions.get(Jenkins.READ);
             if (f!=null) {
                 Set<String> t = grantedPermissions.get(Item.READ);
@@ -311,7 +311,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
             if (jenkins == null) { // Should never happen
                 return FormValidation.error("Jenkins instance is not ready. Cannot validate the field");
             }
-            return doCheckName_(value, Jenkins.getInstance(), Jenkins.ADMINISTER);
+            return doCheckName_(value, Jenkins.getActiveInstance(), Jenkins.ADMINISTER);
         }
 
         public FormValidation doCheckName_(@Nonnull String value, @Nonnull AccessControlled subject, 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     Offers matrix-based security authorization strategies (global and per-project).
 </div>

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 CloudBees.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.hudson.plugins.folder.properties;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import hudson.model.FreeStyleProject;
+import hudson.model.Hudson;
+import hudson.model.Item;
+import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import java.util.concurrent.Callable;
+import org.acegisecurity.AccessDeniedException;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class AuthorizationMatrixPropertyTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void basics1() throws Exception {
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        realm.createAccount("alice","alice");
+        realm.createAccount("bob","bob");
+        r.jenkins.setSecurityRealm(realm);
+
+        ProjectMatrixAuthorizationStrategy as = new ProjectMatrixAuthorizationStrategy();
+        r.jenkins.setAuthorizationStrategy(as);
+        as.add(Hudson.READ,"authenticated");
+
+        Folder f = r.jenkins.createProject(Folder.class, "d");
+        AuthorizationMatrixProperty amp = new AuthorizationMatrixProperty();
+        amp.add(Item.READ,"alice");
+        amp.add(Item.BUILD,"alice");
+        f.getProperties().add(amp);
+
+        final FreeStyleProject foo = f.createProject(FreeStyleProject.class, "foo");
+
+        JenkinsRule.WebClient wc = r.createWebClient().login("bob");
+        try {
+            wc.getPage(foo);
+            fail();
+        } catch (FailingHttpStatusCodeException e) {
+            assertEquals(404, e.getStatusCode());
+        }
+
+        wc = r.createWebClient().login("alice");
+        wc.getPage(foo);    // this should succeed
+
+        // and build permission should be set, too
+        wc.executeOnServer(new Callable<Object>() {
+            public Object call() throws Exception {
+                foo.checkPermission(Item.BUILD);
+                try {
+                    foo.checkPermission(Item.DELETE);
+                    fail("acecss should be denied");
+                } catch (AccessDeniedException e) {
+                    // expected
+                }
+                return null;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Counterpart to https://github.com/jenkinsci/cloudbees-folder-plugin/pull/33, and would have to be released simultaneously to minimize the chance of loss of functionality. (I do not know of a way to _force_ users who upgrade `cloudbees-folder` to also upgrade `matrix-auth`, alas.)

@reviewbybees esp. @stephenc