### PR TITLE
Fixes PCT against 2.x baselines.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.9</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>1.4-SNAPSHOT</version>


### PR DESCRIPTION
Bumping parent pom version fixes PCT against 2.x baselines.

@reviewbybees 