### PR TITLE
Fixes invisible text in .caption-row on #hudson-security-ProjectMatrixAuthorizationStrategy

### DIFF
--- a/src/main/resources/hudson/security/table.css
+++ b/src/main/resources/hudson/security/table.css
@@ -40,6 +40,9 @@
   font-weight: lighter;
   writing-mode: tb-rl; /* works in IE, not FF */
   padding: 0;
+  background-color: #eee;
+  border: 1px solid #D3D7CF;
+  color: #3b3b3b!important;
 }
 
 .global-matrix-authorization-strategy-table TD {


### PR DESCRIPTION
Fixes invisible text in .caption-row on hudson-security-ProjectMatrixAuthorizationStrategy from font-color #f5f5f5!important on white background

Before:
![screen shot 2016-11-01 at 1 58 18 pm](https://cloud.githubusercontent.com/assets/6697003/19901738/8588706a-a03e-11e6-9a94-013e9cb286f4.png)

After:
![screen shot 2016-11-01 at 2 04 19 pm](https://cloud.githubusercontent.com/assets/6697003/19901723/7b48f962-a03e-11e6-95cf-1d6e4dbf826c.png)
