### PR TITLE
[JENKINS-39873] Let subprojects/subfolders choose to ignore parent folder permissions

### DIFF
--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -84,6 +84,8 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
 	private Set<String> sids = new HashSet<String>();
 
     private boolean blocksInheritance = false;
+    
+    private boolean blocksParentInheritance = false;
 
     private AuthorizationMatrixProperty() {
     }
@@ -149,6 +151,9 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
 
             // Disable inheritance, if so configured
             amp.setBlocksInheritance(!formData.getJSONObject("blocksInheritance").isNullObject());
+            
+            // Disable parent inheritance, if so configured
+            amp.setBlocksParentInheritance(!formData.getJSONObject("blocksParentInheritance").isNullObject());
 
             Map<String,Object> data = formData.getJSONObject("data");
             for (Map.Entry<String, Object> r : data.entrySet()) {
@@ -216,7 +221,27 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
 	}
 
 	/**
-	 * Sets the flag to block inheritance
+	 * Sets the flag to block parent inheritance
+	 *
+	 * @param blocksParentInheritance
+	 *            true if the parent inheritance should be blocked
+	 */
+	protected void setBlocksParentInheritance(boolean blocksParentInheritance) {
+		this.blocksParentInheritance = blocksParentInheritance;
+	}
+
+	/**
+	 * Returns true if the authorization matrix is configured to block
+	 * inheritance from the parent.
+	 *
+	 * @return true if the parent inheritance is blocked
+	 */
+	public boolean isBlocksParentInheritance() {
+		return this.blocksParentInheritance;
+	}
+
+	/**
+	 * Sets the flag to block global authorization matrix inheritance
 	 *
 	 * @param blocksInheritance
 	 */
@@ -284,6 +309,12 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
                 writer.setValue("true");
                 writer.endNode();
             }
+            
+            if(amp.isBlocksParentInheritance()) {
+                writer.startNode("blocksParentInheritance");
+                writer.setValue("true");
+                writer.endNode();
+            }
 
             for (Entry<Permission, Set<String>> e : amp.grantedPermissions
 					.entrySet()) {
@@ -312,6 +343,13 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> {
 			    reader.moveDown();
 			    as.setBlocksInheritance("true".equals(reader.getValue()));
 			    reader.moveUp();
+                            prop = reader.peekNextChild(); // We check the next field
+			}
+
+			if("blocksParentInheritance".equals(prop)) {
+				reader.moveDown();
+				as.setBlocksParentInheritance("true".equals(reader.getValue()));
+				reader.moveUp();
 			}
 
 			while (reader.hasMoreChildren()) {

--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -58,11 +58,13 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
         if (amp != null) {
             SidACL projectAcl = amp.getACL();
 
-            if (!amp.isBlocksInheritance()) {
+            if (amp.isBlocksInheritance()) {
+                return projectAcl;
+            } else if (amp.isBlocksParentInheritance()) {
+                return inheritingACL(getRootACL(), projectAcl);
+            } else {
                 final ACL parentAcl = getACL(project.getParent());
                 return inheritingACL(parentAcl, projectAcl);
-            } else {
-                return projectAcl;
             }
         } else {
             return getACL(project.getParent());
@@ -95,7 +97,7 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
             if (item instanceof AbstractFolder) {
                 com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty p = (com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty) ((AbstractFolder) item).getProperties().get(com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty.class);
                 if (p != null) {
-                    return inheritingACL(getACL(item.getParent()), p.getACL());
+                    return inheritingACL(p.isBlocksParentInheritance() ? getRootACL() : getACL(item.getParent()), p.getACL());
                 }
             }
         }

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.jelly
@@ -24,6 +24,12 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
-    <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
+    <f:nested>
+      <table style="width:100%">
+        <f:optionalBlock field="blocksParentInheritance"
+                         title="${%Block inheritance of parent authorization matrix}" />
+        <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
+      </table>
+    </f:nested>
   </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
+++ b/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
@@ -29,6 +29,8 @@ THE SOFTWARE.
       <table style="width:100%">
         <f:optionalBlock field="blocksInheritance"
                          title="${%Block inheritance of global authorization matrix}" />
+        <f:optionalBlock field="blocksParentInheritance"
+                         title="${%Block inheritance of parent authorization matrix}" />
         <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
       </table>
     </f:nested>


### PR DESCRIPTION
The current behavior remains unchanged, but this change adds a toggle to the project and folder configurations which will have that project/folder not inherit the permissions of its parent folder. It will still inherit from the global acl.

When you have a folder structure such as:

* a/b1/foo1
* a/b2/foo2

You can then grant everyone read permission on folder a, grant a certain group read permission on a/b1 which is not set to inherit from the parent folder (but still inherit from the global authorization matrix), then do the same for another group on a/b2. This only lets the groups see their own folders and contents.