### PR TITLE
[JENKINS-29815] Add disabling of permission inheritance for Folders

### DIFF
--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -95,7 +95,14 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
             if (item instanceof AbstractFolder) {
                 com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty p = (com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty) ((AbstractFolder) item).getProperties().get(com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty.class);
                 if (p != null) {
-                    return inheritingACL(getACL(item.getParent()), p.getACL());
+                    SidACL folderAcl = p.getACL();
+
+                    if (!p.isBlocksInheritance()) {
+                        final ACL parentAcl = getACL(item.getParent());
+                        return inheritingACL(parentAcl, folderAcl);
+                    } else {
+                        return folderAcl;
+                    }
                 }
             }
         }

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.jelly
@@ -24,6 +24,12 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
-    <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
+    <f:nested>
+      <table style="width:100%">
+        <f:optionalBlock field="blocksInheritance"
+                         title="${%Block inheritance of global authorization matrix}" />
+        <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
+      </table>
+    </f:nested>
   </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/help-blocksInheritance.html
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/help-blocksInheritance.html
@@ -1,0 +1,9 @@
+<div>
+  If checked, the global configuration matrix will not be inherited.
+  This allows you to configure a Folder that has a more strict access control list than the rest of the global permission set.
+  <br />
+  <br />
+  <b>WARNING</b>:  because the parent ACL will not be inherited, it is possible to revoke your own configuration access accidentally.
+  If you enable this setting, please also remember to grant yourself or your group configuration access so that you do not lock yourself out of the Folder.
+  Otherwise the only ways to get back in will be to disable project-based security in global configuration, or manually edit the permissions list in the project's XML configuration.
+</div>


### PR DESCRIPTION
This adds the same tick-box to disable inheritance of global permissions
to Folders as already exists for Projects. Consistency!

Support for the Folder plugin seems to originally have been done by
copy-pasting in an only slightly modified version of an ancient copy of
the AuthorizationMatrixProperty.java file. This commit is as such very
similar to the patch Kohsuke once applied to the Project's AMP:
6411fffb41e4e7b217d0e841462ef23a8e62c45a

Now, these two files are close to identical, and should be refactored
into one class in my opinion:

    src/main/java/hudson/security/AuthorizationMatrixProperty.java
    src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java