### PR TITLE
[JENKINS-46834] Add flexible inheritance strategies, deprecate 'blocksInheritance'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <version>2.33</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
-    <version>1.8-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Matrix Authorization Strategy Plugin</name>
     <description>Offers matrix-based security authorization strategies (global and per-project).</description>
@@ -58,4 +58,17 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <compatibleSinceVersion>2.0</compatibleSinceVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,9 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.0.4</version>
+            <version>6.1.0</version>
             <optional>true</optional>
         </dependency>
-        <dependency> <!-- TODO JENKINS-33095 workaround -->
-            <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-            <artifactId>icon-shim</artifactId>
-            <version>2.0.3</version>
-       </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>5.2.2</version>
+            <version>6.0.4</version>
             <optional>true</optional>
         </dependency>
         <dependency> <!-- TODO JENKINS-33095 workaround -->
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1.24</version>
+            <version>2.1.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -80,13 +80,12 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
     private Set<String> sids = new HashSet<String>();
 
     @Deprecated
-    private boolean blocksInheritance = false;
+    private transient Boolean blocksInheritance;
 
-    private transient InheritanceStrategy inheritanceStrategy;
+    private InheritanceStrategy inheritanceStrategy = new InheritParentStrategy();
 
 
     protected AuthorizationMatrixProperty() {
-        this.inheritanceStrategy = new InheritParentStrategy();
     }
 
     public AuthorizationMatrixProperty(Map<Permission,? extends Set<String>> grantedPermissions) {
@@ -174,6 +173,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
      *
      * @param blocksInheritance
      */
+    @Deprecated
     public void setBlocksInheritance(boolean blocksInheritance) {
         this.blocksInheritance = blocksInheritance;
     }
@@ -184,7 +184,8 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
      *
      * @return
      */
-    public boolean isBlocksInheritance() {
+    @Deprecated
+    public Boolean isBlocksInheritance() {
         return this.blocksInheritance;
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -79,6 +79,9 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
 
     private Set<String> sids = new HashSet<String>();
 
+    /**
+     * @deprecated unused, use {@link #setInheritanceStrategy(InheritanceStrategy)} instead.
+     */
     @Deprecated
     private transient Boolean blocksInheritance;
 
@@ -169,30 +172,17 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
     }
 
     /**
-     * Sets the flag to block inheritance
-     *
-     * @param blocksInheritance
+     * @since TODO
+     * @param inheritanceStrategy
      */
-    @Deprecated
-    public void setBlocksInheritance(boolean blocksInheritance) {
-        this.blocksInheritance = blocksInheritance;
-    }
-
-    /**
-     * Returns true if the authorization matrix is configured to block
-     * inheritance from the parent.
-     *
-     * @return
-     */
-    @Deprecated
-    public Boolean isBlocksInheritance() {
-        return this.blocksInheritance;
-    }
-
     public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
         this.inheritanceStrategy = inheritanceStrategy;
     }
 
+    /**
+     * @since TODO
+     * @return
+     */
     public InheritanceStrategy getInheritanceStrategy() {
         return inheritanceStrategy;
     }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -171,18 +171,10 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
         return acl;
     }
 
-    /**
-     * @since TODO
-     * @param inheritanceStrategy
-     */
     public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
         this.inheritanceStrategy = inheritanceStrategy;
     }
 
-    /**
-     * @since TODO
-     * @return
-     */
     public InheritanceStrategy getInheritanceStrategy() {
         return inheritanceStrategy;
     }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -47,6 +47,8 @@ import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.Sid;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -77,9 +79,14 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
 
     private Set<String> sids = new HashSet<String>();
 
+    @Deprecated
     private boolean blocksInheritance = false;
 
+    private transient InheritanceStrategy inheritanceStrategy;
+
+
     protected AuthorizationMatrixProperty() {
+        this.inheritanceStrategy = new InheritParentStrategy();
     }
 
     public AuthorizationMatrixProperty(Map<Permission,? extends Set<String>> grantedPermissions) {
@@ -179,6 +186,14 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
      */
     public boolean isBlocksInheritance() {
         return this.blocksInheritance;
+    }
+
+    public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
+        this.inheritanceStrategy = inheritanceStrategy;
+    }
+
+    public InheritanceStrategy getInheritanceStrategy() {
+        return inheritanceStrategy;
     }
 
     /**

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -55,6 +55,8 @@ import org.jenkinsci.plugins.matrixauth.AuthorizationMatrixPropertyDescriptor;
 import org.jenkinsci.plugins.matrixauth.AuthorizationProperty;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -79,7 +81,13 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 
 	private Set<String> sids = new HashSet<String>();
 
-    private boolean blocksInheritance = false;
+	@Deprecated
+    private transient Boolean blocksInheritance = false;
+
+	/**
+	 * @since TODO
+	 */
+	private InheritanceStrategy inheritanceStrategy = new InheritParentStrategy();
 
     private AuthorizationMatrixProperty() {
     }
@@ -171,6 +179,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	 *
 	 * @param blocksInheritance
 	 */
+	@Deprecated
 	public void setBlocksInheritance(boolean blocksInheritance) {
 		this.blocksInheritance = blocksInheritance;
 	}
@@ -181,8 +190,17 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	 *
 	 * @return
 	 */
+	@Deprecated
 	public boolean isBlocksInheritance() {
 		return this.blocksInheritance;
+	}
+
+	public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
+		this.inheritanceStrategy = inheritanceStrategy;
+	}
+
+	public InheritanceStrategy getInheritanceStrategy() {
+		return inheritanceStrategy;
 	}
 
 	/**

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -82,7 +82,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	private Set<String> sids = new HashSet<String>();
 
 	@Deprecated
-    private transient Boolean blocksInheritance = false;
+    private transient Boolean blocksInheritance;
 
 	/**
 	 * @since TODO
@@ -191,7 +191,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	 * @return
 	 */
 	@Deprecated
-	public boolean isBlocksInheritance() {
+	public Boolean isBlocksInheritance() {
 		return this.blocksInheritance;
 	}
 

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -174,18 +174,10 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 		return acl;
 	}
 
-	/**
-	 * @since TODO
-	 * @param inheritanceStrategy
-	 */
 	public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
 		this.inheritanceStrategy = inheritanceStrategy;
 	}
 
-	/**
-	 * @since TODO
-	 * @return
-	 */
 	public InheritanceStrategy getInheritanceStrategy() {
 		return inheritanceStrategy;
 	}

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -81,12 +81,12 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 
 	private Set<String> sids = new HashSet<String>();
 
+	/**
+	 * @deprecated unused, use {@link #setInheritanceStrategy(InheritanceStrategy)} instead.
+	 */
 	@Deprecated
     private transient Boolean blocksInheritance;
 
-	/**
-	 * @since TODO
-	 */
 	private InheritanceStrategy inheritanceStrategy = new InheritParentStrategy();
 
     private AuthorizationMatrixProperty() {
@@ -175,30 +175,17 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	}
 
 	/**
-	 * Sets the flag to block inheritance
-	 *
-	 * @param blocksInheritance
+	 * @since TODO
+	 * @param inheritanceStrategy
 	 */
-	@Deprecated
-	public void setBlocksInheritance(boolean blocksInheritance) {
-		this.blocksInheritance = blocksInheritance;
-	}
-
-	/**
-	 * Returns true if the authorization matrix is configured to block
-	 * inheritance from the parent.
-	 *
-	 * @return
-	 */
-	@Deprecated
-	public Boolean isBlocksInheritance() {
-		return this.blocksInheritance;
-	}
-
 	public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
 		this.inheritanceStrategy = inheritanceStrategy;
 	}
 
+	/**
+	 * @since TODO
+	 * @return
+	 */
 	public InheritanceStrategy getInheritanceStrategy() {
 		return inheritanceStrategy;
 	}

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -432,8 +432,18 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
         }
 
         public List<PermissionGroup> getAllGroups() {
-            List<PermissionGroup> groups = new ArrayList<PermissionGroup>(PermissionGroup.getAll());
-            groups.remove(PermissionGroup.get(Permission.class));
+            List<PermissionGroup> groups = new ArrayList<PermissionGroup>();
+            for (PermissionGroup group : PermissionGroup.getAll()) {
+                if (group == PermissionGroup.get(Permission.class)) {
+                    continue;
+                }
+                for (Permission p : group.getPermissions()) {
+                    if (p.getEnabled()) {
+                        groups.add(group);
+                        break;
+                    }
+                }
+            }
             return groups;
         }
 

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -594,7 +594,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
     /**
      * Backwards compatibility: Enable granting dangerous permissions independently of Administer access.
      *
-     * @since TODO
+     * @since 1.5
      */
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     @Restricted(NoExternalUse.class)

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractMatrixPropertyConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractMatrixPropertyConverter.java
@@ -94,7 +94,7 @@ public abstract class AbstractMatrixPropertyConverter implements Converter {
             try {
                 authorizationProperty.setInheritanceStrategy((InheritanceStrategy) Class.forName(clazz).newInstance());
             } catch (Exception e) {
-                // TODO logging
+                LOGGER.log(Level.WARNING, "Failed to restore inheritance strategy", e);
             }
             reader.moveUp();
         }
@@ -113,4 +113,6 @@ public abstract class AbstractMatrixPropertyConverter implements Converter {
 
         return authorizationProperty;
     }
+
+    public static final Logger LOGGER = Logger.getLogger(AbstractMatrixPropertyConverter.class.getName());
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractMatrixPropertyConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractMatrixPropertyConverter.java
@@ -31,6 +31,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import hudson.security.AuthorizationMatrixProperty;
 import hudson.security.Permission;
 import hudson.util.RobustReflectionConverter;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
 

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -44,6 +44,8 @@ import org.acegisecurity.acls.sid.PrincipalSid;
 import org.acegisecurity.acls.sid.Sid;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritGlobalStrategy;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -66,7 +68,10 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
 
     private Set<String> sids = new HashSet<String>();
 
-    private boolean blocksInheritance = false;
+    @Deprecated
+    private transient boolean blocksInheritance = false;
+
+    private InheritanceStrategy inheritanceStrategy = new InheritGlobalStrategy();
 
     private AuthorizationMatrixNodeProperty() {
     }
@@ -89,6 +94,14 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
      */
     public Map<Permission,Set<String>> getGrantedPermissions() {
         return Collections.unmodifiableMap(grantedPermissions);
+    }
+
+    public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
+        this.inheritanceStrategy = inheritanceStrategy;
+    }
+
+    public InheritanceStrategy getInheritanceStrategy() {
+        return inheritanceStrategy;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -69,7 +69,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
     private Set<String> sids = new HashSet<String>();
 
     @Deprecated
-    private transient boolean blocksInheritance = false;
+    private transient Boolean blocksInheritance;
 
     private InheritanceStrategy inheritanceStrategy = new InheritGlobalStrategy();
 
@@ -118,7 +118,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
     }
 
     @Override
-    public boolean isBlocksInheritance() {
+    public Boolean isBlocksInheritance() {
         return blocksInheritance;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -99,18 +99,10 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
         return Collections.unmodifiableMap(grantedPermissions);
     }
 
-    /**
-     * @since TODO
-     * @param inheritanceStrategy
-     */
     public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
         this.inheritanceStrategy = inheritanceStrategy;
     }
 
-    /**
-     * @since TODO
-     * @return
-     */
     public InheritanceStrategy getInheritanceStrategy() {
         return inheritanceStrategy;
     }
@@ -187,7 +179,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
         }
 
         public FormValidation doCheckName(@AncestorInPath Computer computer, @QueryParameter String value) throws IOException, ServletException {
-            // TODO Computer needs to become a DescriptorByNameOwner for the AncestorInPath to work
+            // Computer isn't a DescriptorByNameOwner before Jenkins 2.78, and then @AncestorInPath doesn't work
             return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value,
                     computer == null ? Jenkins.getInstance() : computer,
                     computer == null ? Jenkins.ADMINISTER : Computer.CONFIGURE);

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -68,6 +68,9 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
 
     private Set<String> sids = new HashSet<String>();
 
+    /**
+     * @deprecated unused, use {@link #setInheritanceStrategy(InheritanceStrategy)} instead.
+     */
     @Deprecated
     private transient Boolean blocksInheritance;
 
@@ -96,10 +99,18 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
         return Collections.unmodifiableMap(grantedPermissions);
     }
 
+    /**
+     * @since TODO
+     * @param inheritanceStrategy
+     */
     public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
         this.inheritanceStrategy = inheritanceStrategy;
     }
 
+    /**
+     * @since TODO
+     * @return
+     */
     public InheritanceStrategy getInheritanceStrategy() {
         return inheritanceStrategy;
     }
@@ -115,16 +126,6 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
             grantedPermissions.put(p, set = new HashSet<String>());
         set.add(sid);
         sids.add(sid);
-    }
-
-    @Override
-    public Boolean isBlocksInheritance() {
-        return blocksInheritance;
-    }
-
-    @Override
-    public void setBlocksInheritance(boolean blocksInheritance) {
-        this.blocksInheritance = blocksInheritance;
     }
 
     private final class AclImpl extends SidACL {

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixPropertyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixPropertyDescriptor.java
@@ -72,11 +72,7 @@ public interface AuthorizationMatrixPropertyDescriptor<T extends AuthorizationPr
 
     default boolean isApplicable() {
         // only applicable when ProjectMatrixAuthorizationStrategy is in charge
-        try {
-            return Jenkins.getInstance().getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy;
-        } catch (NoClassDefFoundError x) { // after matrix-auth split?
-            return false;
-        }
+        return Jenkins.getInstance().getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy;
     }
 
     default String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixPropertyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixPropertyDescriptor.java
@@ -30,6 +30,7 @@ import hudson.security.PermissionScope;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.ArrayList;
@@ -52,8 +53,7 @@ public interface AuthorizationMatrixPropertyDescriptor<T extends AuthorizationPr
 
         T amnp = createProperty();
 
-        // Disable inheritance, if so configured
-        amnp.setBlocksInheritance(!formData.getJSONObject("blocksInheritance").isNullObject());
+        amnp.setInheritanceStrategy(req.bindJSON(InheritanceStrategy.class, formData.getJSONObject("inheritanceStrategy")));
 
         for (Map.Entry<String, Object> r : (Set<Map.Entry<String, Object>>) formData.getJSONObject("data").entrySet()) {
             String sid = r.getKey();

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -23,14 +23,12 @@
  */
 package org.jenkinsci.plugins.matrixauth;
 
-import hudson.ExtensionList;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
-import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategyDescriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -48,7 +46,7 @@ public interface AuthorizationProperty {
     InheritanceStrategy getInheritanceStrategy();
 
     @Deprecated
-    boolean isBlocksInheritance();
+    Boolean isBlocksInheritance();
 
     @Deprecated
     void setBlocksInheritance(boolean blocksInheritance);

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -155,9 +155,4 @@ public interface AuthorizationProperty {
         Arrays.sort(data);
         return Arrays.asList(data);
     }
-
-    @Restricted(NoExternalUse.class)
-    default ExtensionList<InheritanceStrategyDescriptor> getInheritanceStrategies() {
-        return InheritanceStrategyDescriptor.all();
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -58,6 +58,7 @@ public interface AuthorizationProperty {
      * Note that for items nested inside folders, this will change behavior significantly.
      *
      * @param blocksInheritance
+     * @since 2.0
      * @deprecated
      */
     @Deprecated
@@ -77,6 +78,7 @@ public interface AuthorizationProperty {
      * if and only if the selected inheritance strategy is {@link NonInheritingStrategy}.
      *
      * @return
+     * @since 2.0
      * @deprecated
      */
     @Deprecated

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -23,11 +23,14 @@
  */
 package org.jenkinsci.plugins.matrixauth;
 
+import hudson.ExtensionList;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategyDescriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -41,7 +44,13 @@ public interface AuthorizationProperty {
     void add(Permission permission, String sid);
     Map<Permission, Set<String>> getGrantedPermissions();
 
+    void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy);
+    InheritanceStrategy getInheritanceStrategy();
+
+    @Deprecated
     boolean isBlocksInheritance();
+
+    @Deprecated
     void setBlocksInheritance(boolean blocksInheritance);
 
     /**
@@ -99,6 +108,9 @@ public interface AuthorizationProperty {
      * Checks if the permission is explicitly given, instead of implied through {@link Permission#impliedBy}.
      */
     default boolean hasExplicitPermission(String sid, Permission p) {
+        if (sid == null) { // used for template row in UI
+            return false;
+        }
         Set<String> set = getGrantedPermissions().get(p);
         if (set != null && p.getEnabled()) {
             if (set.contains(sid))
@@ -144,4 +156,8 @@ public interface AuthorizationProperty {
         return Arrays.asList(data);
     }
 
+    @Restricted(NoExternalUse.class)
+    default ExtensionList<InheritanceStrategyDescriptor> getInheritanceStrategies() {
+        return InheritanceStrategyDescriptor.all();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -28,7 +28,9 @@ import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritGlobalStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
+import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -45,11 +47,42 @@ public interface AuthorizationProperty {
     void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy);
     InheritanceStrategy getInheritanceStrategy();
 
+    /**
+     * Sets the flag to block inheritance.
+     *
+     * Since the introduction of inheritance strategies, set the inheritance
+     * strategy roughly matching the previous behavior, i.e. {@code false} will
+     * set the {@link NonInheritingStrategy}, {@code true} will set the
+     * {@link InheritGlobalStrategy}.
+     *
+     * Note that for items nested inside folders, this will change behavior significantly.
+     *
+     * @param blocksInheritance
+     * @deprecated
+     */
     @Deprecated
-    Boolean isBlocksInheritance();
+    default void setBlocksInheritance(boolean blocksInheritance) {
+        if (blocksInheritance) {
+            setInheritanceStrategy(new NonInheritingStrategy());
+        } else {
+            setInheritanceStrategy(new InheritGlobalStrategy());
+        }
+    }
 
+    /**
+     * Returns true if the authorization matrix is configured to block
+     * inheritance from the parent.
+     *
+     * Since the introduction of inheritance strategies, returns {@code true}
+     * if and only if the selected inheritance strategy is {@link NonInheritingStrategy}.
+     *
+     * @return
+     * @deprecated
+     */
     @Deprecated
-    void setBlocksInheritance(boolean blocksInheritance);
+    default boolean isBlocksInheritance() {
+        return getInheritanceStrategy() instanceof NonInheritingStrategy;
+    }
 
     /**
      * Checks if the given SID has the given permission.

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.jenkinsci.plugins.matrixauth.inheritance;
 
 import hudson.Extension;
@@ -35,7 +58,7 @@ public class InheritGlobalStrategy extends InheritanceStrategy {
         @Override
         @Nonnull
         public String getDisplayName() {
-            return "Inherit globally defined permissions"; // TODO i18n
+            return Messages.InheritGlobalStrategy_DisplayName();
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.plugins.matrixauth.inheritance;
+
+import hudson.Extension;
+import hudson.security.ACL;
+import hudson.security.AccessControlled;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Strategy that inherits only the global ACL -- parent, grandparent, etc. ACLs are not inherited.
+ */
+public class InheritGlobalStrategy extends InheritanceStrategy {
+
+    @DataBoundConstructor
+    public InheritGlobalStrategy() {
+
+    }
+    
+    @Override
+    public ACL getEffectiveACL(ACL acl, AccessControlled subject) {
+        return ProjectMatrixAuthorizationStrategy.inheritingACL(Jenkins.getInstance().getAuthorizationStrategy().getRootACL(), acl);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends InheritanceStrategyDescriptor {
+
+        @Override
+        public boolean isApplicable(Class<?> clazz) {
+            return true;
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Inherit globally defined permissions"; // TODO i18n
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy.java
@@ -1,0 +1,57 @@
+package org.jenkinsci.plugins.matrixauth.inheritance;
+
+import hudson.Extension;
+import hudson.model.AbstractItem;
+import hudson.model.ItemGroup;
+import hudson.security.ACL;
+import hudson.security.AccessControlled;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Strategy that inherits the ACL from the parent.
+ *
+ * The paren't inheritance strategy in turn determines whether this receives permissions from grandparents etc. up to root.
+ */
+public class InheritParentStrategy extends InheritanceStrategy {
+
+    @DataBoundConstructor
+    public InheritParentStrategy() {
+
+    }
+
+    @Override
+    public ACL getEffectiveACL(ACL acl, AccessControlled subject) {
+        if (subject instanceof AbstractItem) {
+            AbstractItem item = (AbstractItem) subject;
+            ItemGroup parent = item.getParent();
+            final ACL parentACL;
+            if (parent instanceof AbstractItem) {
+                parentACL = Jenkins.getInstance().getAuthorizationStrategy().getACL((AbstractItem) parent);
+            } else {
+                parentACL = Jenkins.getInstance().getAuthorizationStrategy().getRootACL();
+            }
+            return ProjectMatrixAuthorizationStrategy.inheritingACL(parentACL, acl);
+        } else {
+            throw new IllegalArgumentException("Expected subject to be AbstractItem, but got " + subject);
+        }
+    }
+
+    @Extension(ordinal = 100)
+    public static class DescriptorImpl extends InheritanceStrategyDescriptor {
+
+        @Override
+        public boolean isApplicable(Class<?> clazz) {
+            return AbstractItem.class.isAssignableFrom(clazz);
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Inherit permissions from parent ACL"; // TODO i18n
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.jenkinsci.plugins.matrixauth.inheritance;
 
 import hudson.Extension;
@@ -51,7 +74,7 @@ public class InheritParentStrategy extends InheritanceStrategy {
         @Override
         @Nonnull
         public String getDisplayName() {
-            return "Inherit permissions from parent ACL"; // TODO i18n
+            return Messages.InheritParentStrategy_DisplayName();
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategy.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.matrixauth.inheritance;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.security.ACL;
+import hudson.security.AccessControlled;
+
+public abstract class InheritanceStrategy extends AbstractDescribableImpl<InheritanceStrategy> implements ExtensionPoint {
+    @Override
+    public InheritanceStrategyDescriptor getDescriptor() {
+        return (InheritanceStrategyDescriptor) super.getDescriptor();
+    }
+
+    public abstract ACL getEffectiveACL(ACL acl, AccessControlled subject);
+}

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategy.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.jenkinsci.plugins.matrixauth.inheritance;
 
 import hudson.ExtensionPoint;

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategyDescriptor.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.jenkinsci.plugins.matrixauth.inheritance;
 
 import hudson.DescriptorExtensionList;

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategyDescriptor.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.matrixauth.inheritance;
+
+import hudson.DescriptorExtensionList;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class InheritanceStrategyDescriptor extends Descriptor<InheritanceStrategy> {
+
+    public static DescriptorExtensionList<InheritanceStrategy, InheritanceStrategyDescriptor> all() {
+        return Jenkins.getInstance().getDescriptorList(InheritanceStrategy.class);
+    }
+
+    public static List<InheritanceStrategyDescriptor> getApplicableDescriptors(Class<?> clazz) {
+        List<InheritanceStrategyDescriptor> result = new ArrayList<>();
+        List<InheritanceStrategyDescriptor> list = all();
+        for (InheritanceStrategyDescriptor isd : list) {
+            if (isd.isApplicable(clazz)) {
+                result.add(isd);
+            }
+        }
+        return result;
+    }
+    
+    public abstract boolean isApplicable(Class<?> clazz);
+
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+        return super.getDisplayName();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.jenkinsci.plugins.matrixauth.inheritance;
 
 import hudson.Extension;
@@ -26,8 +49,7 @@ public class NonInheritingStrategy extends InheritanceStrategy {
         return new ACL() {
             @Override
             public boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission permission) {
-                if (isUltimatelyImpliedByAdminister(permission) && rootACL.hasPermission(a, Jenkins.ADMINISTER)) {
-                    /*
+                /*
                     I see two possible approaches here:
                     One would be to just grant every permission if the root ACL grants Administer.
                     This could result in weird situations where disabling inheritance would grant permissions like the optional
@@ -36,9 +58,7 @@ public class NonInheritingStrategy extends InheritanceStrategy {
                     Administer, and, if so, grants it if the user has Administer.
                     As this is a tree, any permission implication rooted in Administer should then be granted to administrators.
                      */
-                    return true;
-                }
-                return acl.hasPermission(a, permission);
+                return isUltimatelyImpliedByAdminister(permission) && rootACL.hasPermission(a, Jenkins.ADMINISTER) || acl.hasPermission(a, permission);
             }
 
             private boolean isUltimatelyImpliedByAdminister(Permission permission) {
@@ -61,7 +81,7 @@ public class NonInheritingStrategy extends InheritanceStrategy {
         @Override
         @Nonnull
         public String getDisplayName() {
-            return "Do not inherit permission grants from other ACLs"; // TODO i18n
+            return Messages.NonInheritingStrategy_DisplayName();
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.matrixauth.inheritance;
+
+import hudson.Extension;
+import hudson.security.ACL;
+import hudson.security.AccessControlled;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Strategy that disables inheritance except for the globally defined Administer permission.
+ */
+public class NonInheritingStrategy extends InheritanceStrategy {
+
+    @DataBoundConstructor
+    public NonInheritingStrategy() {
+
+    }
+
+    @Override
+    public ACL getEffectiveACL(ACL acl, AccessControlled subject) {
+        final ACL rootACL = Jenkins.getInstance().getAuthorizationStrategy().getRootACL();
+        return new ACL() {
+            @Override
+            public boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission permission) {
+                if (isUltimatelyImpliedByAdminister(permission) && rootACL.hasPermission(a, Jenkins.ADMINISTER)) {
+                    /*
+                    I see two possible approaches here:
+                    One would be to just grant every permission if the root ACL grants Administer.
+                    This could result in weird situations where disabling inheritance would grant permissions like the optional
+                    Run/Artifacts permission not implied by anything else.
+                    The chosen, second approach checks whether the given permission is ultimately (transitively) implied by
+                    Administer, and, if so, grants it if the user has Administer.
+                    As this is a tree, any permission implication rooted in Administer should then be granted to administrators.
+                     */
+                    return true;
+                }
+                return acl.hasPermission(a, permission);
+            }
+
+            private boolean isUltimatelyImpliedByAdminister(Permission permission) {
+                while (permission.impliedBy != null) {
+                    permission = permission.impliedBy;
+                }
+                return permission == Jenkins.ADMINISTER;
+            }
+        };
+    }
+    
+    @Extension(ordinal = -100)
+    public static class DescriptorImpl extends InheritanceStrategyDescriptor {
+
+        @Override
+        public boolean isApplicable(Class<?> clazz) {
+            return true;
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Do not inherit permission grants from other ACLs"; // TODO i18n
+        }
+    }
+}

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.groovy
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.groovy
@@ -1,0 +1,16 @@
+package com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty
+
+import lib.FormTagLib
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategyDescriptor
+
+def f = namespace(FormTagLib)
+def st = namespace("jelly:stapler")
+
+f.optionalBlock(name: 'useProjectSecurity', checked: instance != null, title: _("Enable project-based security")) {
+    f.nested {
+        table(style: "width: 100%") {
+            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(Node.class), field: 'inheritanceStrategy')
+            st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
+        }
+    }
+}

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.groovy
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.groovy
@@ -9,7 +9,7 @@ def st = namespace("jelly:stapler")
 f.optionalBlock(name: 'useProjectSecurity', checked: instance != null, title: _("Enable project-based security")) {
     f.nested {
         table(style: "width: 100%") {
-            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(Node.class), field: 'inheritanceStrategy')
+            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(my.class), field: 'inheritanceStrategy')
             st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
         }
     }

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/help-blocksInheritance.html
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/help-blocksInheritance.html
@@ -1,9 +1,0 @@
-<div>
-  If checked, the global configuration matrix will not be inherited.
-  This allows you to configure a Folder that has a more strict access control list than the rest of the global permission set.
-  <br />
-  <br />
-  <b>WARNING</b>:  because the parent ACL will not be inherited, it is possible to revoke your own configuration access accidentally.
-  If you enable this setting, please also remember to grant yourself or your group configuration access so that you do not lock yourself out of the Folder.
-  Otherwise the only ways to get back in will be to disable project-based security in global configuration, or manually edit the permissions list in the project's XML configuration.
-</div>

--- a/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.groovy
+++ b/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.groovy
@@ -1,0 +1,16 @@
+package com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty
+
+import lib.FormTagLib
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategyDescriptor
+
+def f = namespace(FormTagLib)
+def st = namespace("jelly:stapler")
+
+f.optionalBlock(name: 'useProjectSecurity', checked: instance != null, title: _("Enable project-based security")) {
+    f.nested {
+        table(style: "width: 100%") {
+            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(Node.class), field: 'inheritanceStrategy')
+            st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
+        }
+    }
+}

--- a/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.groovy
+++ b/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.groovy
@@ -9,7 +9,7 @@ def st = namespace("jelly:stapler")
 f.optionalBlock(name: 'useProjectSecurity', checked: instance != null, title: _("Enable project-based security")) {
     f.nested {
         table(style: "width: 100%") {
-            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(Node.class), field: 'inheritanceStrategy')
+            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(my.class), field: 'inheritanceStrategy')
             st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
         }
     }

--- a/src/main/resources/hudson/security/AuthorizationMatrixProperty/help-blocksInheritance.html
+++ b/src/main/resources/hudson/security/AuthorizationMatrixProperty/help-blocksInheritance.html
@@ -1,9 +1,0 @@
-<div>
-  If checked, the global configuration matrix will not be inherited.
-  This allows you to configure a job that has a more strict access control list than the rest of the global permission set.
-  <br />
-  <br />
-  <b>WARNING</b>:  because the parent ACL will not be inherited, it is possible to revoke your own configuration access accidentally.
-  If you enable this setting, please also remember to grant yourself or your group configuration access so that you do not lock yourself out of the job.
-  Otherwise the only ways to get back in will be to disable project-based security in global configuration, or manually edit the permissions list in the project's XML configuration.
-</div>

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.groovy
@@ -9,7 +9,6 @@ def st = namespace("jelly:stapler")
 f.nested {
     table(style: "width: 100%") {
         f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(my.class), field: 'inheritanceStrategy')
-//        f.optionalBlock(field: "blocksInheritance", title:_("Block inheritance of global authorization matrix"))
         st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.groovy
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.matrixauth.AuthorizationMatrixNodeProperty
+
+import lib.FormTagLib
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategyDescriptor
+
+def f = namespace(FormTagLib)
+def st = namespace("jelly:stapler")
+
+f.nested {
+    table(style: "width: 100%") {
+        f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(Node.class), field: 'inheritanceStrategy')
+//        f.optionalBlock(field: "blocksInheritance", title:_("Block inheritance of global authorization matrix"))
+        st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.groovy
@@ -8,7 +8,7 @@ def st = namespace("jelly:stapler")
 
 f.nested {
     table(style: "width: 100%") {
-        f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(Node.class), field: 'inheritanceStrategy')
+        f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(my.class), field: 'inheritanceStrategy')
 //        f.optionalBlock(field: "blocksInheritance", title:_("Block inheritance of global authorization matrix"))
         st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
     }

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/Messages.properties
@@ -22,5 +22,6 @@
 
 GlobalMatrixAuthorizationStrategy.DisplayName=Matrix-based security
 ProjectMatrixAuthorizationStrategy.DisplayName=Project-based Matrix Authorization Strategy
+AuthorizationMatrixNodeProperty.DisplayName=Enable node-based security
 GlobalMatrixAuthorizationStrategy.PermissionImpliedBy=This permission is implied by {0}/{1}.
 GlobalMatrixAuthorizationStrategy.PermissionNotImpliedBy=This permission is <strong>not</strong> implied by Overall/Administer. It needs to be explicitly granted even to administrators.

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+Copyright (c) 2017, CloudBees, Inc., Daniel Beck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,13 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
-    <f:nested>
-      <table style="width:100%">
-        <f:optionalBlock field="blocksInheritance"
-                         title="${%Block inheritance of global authorization matrix}" />
-        <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
-      </table>
-    </f:nested>
-  </f:optionalBlock>
+    <f:description>${%blurb(rootURL)}</f:description>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.properties
@@ -1,0 +1,1 @@
+blurb = This object will inherit the <a href="{0}/configureSecurity">global security security settings</a>.

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.properties
@@ -1,1 +1,2 @@
-blurb = This object will inherit the <a href="{0}/configureSecurity">global security security settings</a>.
+blurb = This object will inherit the <a href="{0}/configureSecurity">global security security settings</a> \
+  directly, but not any permissions granted in ancestor items, if any.

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright 2013 CloudBees.
+Copyright (c) 2017, CloudBees, Inc., Daniel Beck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,15 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
-    <f:nested>
-      <table style="width:100%">
-        <f:optionalBlock field="blocksInheritance"
-                         title="${%Block inheritance of global authorization matrix}" />
-        <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
-      </table>
-    </f:nested>
-  </f:optionalBlock>
+    <f:description>${%blurb(rootURL)}</f:description>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.properties
@@ -1,0 +1,2 @@
+blurb = This item will inherit its parent item's permissions (in addition to any permissions granted here).\
+        If this item is at the top level in Jenkins, it will inherit the <a href="{0}/configureSecurity">global security security settings</a>.

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategy/config.jelly
@@ -1,0 +1,28 @@
+<!--
+The MIT License
+
+Copyright (c) 2017, CloudBees, Inc., Daniel Beck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <!-- empty default -->
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/Messages.properties
@@ -1,0 +1,3 @@
+InheritGlobalStrategy.DisplayName=Inherit globally defined permissions
+InheritParentStrategy.DisplayName=Inherit permissions from parent ACL
+NonInheritingStrategy.DisplayName=Do not inherit permission grants from other ACLs

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+Copyright (c) 2017, CloudBees, Inc., Daniel Beck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:nested>
-        <table style="width:100%">
-            <f:optionalBlock field="blocksInheritance"
-                             title="${%Block inheritance of global authorization matrix}" />
-            <st:include class="hudson.security.GlobalMatrixAuthorizationStrategy" page="config.jelly"/>
-        </table>
-    </f:nested>
+    <f:description>${%blurb(rootURL)}</f:description>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.properties
@@ -1,0 +1,3 @@
+blurb = This object will <strong>not</strong> inherit the <a href="{0}/configureSecurity">global security security settings</a>.\
+  To ensure that users are not inadvertently locked out from Jenkins, an exception is made for the <strong>Overall/Administer</strong> permission:\
+  Administrators of Jenkins will still have access to this object even if not explicitly granted here.

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.properties
@@ -1,3 +1,3 @@
-blurb = This object will <strong>not</strong> inherit the <a href="{0}/configureSecurity">global security security settings</a>.\
-  To ensure that users are not inadvertently locked out from Jenkins, an exception is made for the <strong>Overall/Administer</strong> permission:\
+blurb = This object will <strong>not</strong> inherit the <a href="{0}/configureSecurity">global security security settings</a>, or any permissions from its ancestors. \
+  To ensure that users are not inadvertently locked out from Jenkins, an exception is made for the <strong>Overall/Administer</strong> permission: \
   Administrators of Jenkins will still have access to this object even if not explicitly granted here.

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
@@ -41,6 +41,8 @@ import org.acegisecurity.AccessDeniedException;
 import static org.junit.Assert.*;
 
 import org.junit.Assert;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
+import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -85,7 +87,7 @@ public class AuthorizationMatrixPropertyTest {
         Folder f = r.jenkins.createProject(Folder.class, "d");
         AuthorizationMatrixProperty amp = new AuthorizationMatrixProperty();
 
-        assertEquals(amp.isBlocksInheritance(), false); // inherit permissions by default
+        assertTrue(amp.getInheritanceStrategy() instanceof InheritParentStrategy);
 
         amp.add(Item.READ,"alice");
         amp.add(Item.BUILD,"alice");
@@ -131,7 +133,7 @@ public class AuthorizationMatrixPropertyTest {
 
         Folder f = r.jenkins.createProject(Folder.class, "d");
         AuthorizationMatrixProperty amp = new AuthorizationMatrixProperty();
-        amp.setBlocksInheritance(true);
+        amp.setInheritanceStrategy(new NonInheritingStrategy());
         amp.add(Item.READ,"alice");
         f.getProperties().add(amp);
 

--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -1,17 +1,24 @@
 package hudson.security;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlLabel;
+import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.User;
 import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
+
+import java.util.Collections;
 
 public class ProjectMatrixAuthorizationStrategyTest {
 
@@ -117,5 +124,55 @@ public class ProjectMatrixAuthorizationStrategyTest {
         Assert.assertTrue(authorizationStrategy.hasExplicitPermission("alice", Jenkins.ADMINISTER));
         Assert.assertFalse(authorizationStrategy.hasExplicitPermission("alice", Jenkins.READ));
         Assert.assertFalse(authorizationStrategy.hasExplicitPermission("bob", Jenkins.ADMINISTER));
+    }
+
+    @Test
+    @Issue("JENKINS-39873")
+    public void subdirectoriesCanExcludeOtherNonAdminUsers() throws Exception {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.createAccount("admin", "admin");
+        securityRealm.createAccount("alice", "alice");
+        securityRealm.createAccount("bob", "bob");
+        securityRealm.createAccount("carol", "carol");
+        r.jenkins.setSecurityRealm(securityRealm);
+
+
+        ProjectMatrixAuthorizationStrategy authorizationStrategy = new ProjectMatrixAuthorizationStrategy();
+        authorizationStrategy.add(Jenkins.ADMINISTER, "admin");
+        authorizationStrategy.add(Jenkins.READ, "alice");
+        authorizationStrategy.add(Jenkins.READ, "bob");
+
+        r.jenkins.setAuthorizationStrategy(authorizationStrategy);
+
+
+        Folder f = r.jenkins.createProject(Folder.class, "Folder");
+
+        com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty amp = new com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty(Collections.emptyMap());
+
+        amp.add(Item.READ,"alice");
+        amp.add(Item.READ,"bob");
+        f.getProperties().add(amp);
+
+        Folder aliceProjects = f.createProject(Folder.class, "alice");
+
+        com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty aliceProp = new com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty(Collections.emptyMap());
+        aliceProp.setInheritanceStrategy(new NonInheritingStrategy());
+        aliceProp.add(Item.READ, "alice");
+        aliceProp.add(Item.CONFIGURE, "alice");
+
+        aliceProjects.getProperties().add(aliceProp);
+
+        ACL acl = r.jenkins.getAuthorizationStrategy().getACL(aliceProjects);
+
+        Authentication alice = User.get("alice").impersonate();
+        Authentication admin = User.get("admin").impersonate();
+        Authentication bob = User.get("bob").impersonate();
+
+        Assert.assertTrue(acl.hasPermission(alice, Item.READ));
+        Assert.assertTrue(acl.hasPermission(alice, Item.CONFIGURE));
+        Assert.assertTrue(acl.hasPermission(admin, Item.READ));
+        Assert.assertTrue(acl.hasPermission(admin, Item.CONFIGURE));
+        Assert.assertFalse(acl.hasPermission(bob, Item.READ));
+        Assert.assertFalse(acl.hasPermission(bob, Item.CONFIGURE));
     }
 }

--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -174,5 +174,19 @@ public class ProjectMatrixAuthorizationStrategyTest {
         Assert.assertTrue(acl.hasPermission(admin, Item.CONFIGURE));
         Assert.assertFalse(acl.hasPermission(bob, Item.READ));
         Assert.assertFalse(acl.hasPermission(bob, Item.CONFIGURE));
+
+        JenkinsRule.WebClient wc = r.createWebClient().login("alice", "alice");
+        wc.goTo(aliceProjects.getUrl());
+
+        wc = r.createWebClient().login("admin", "admin");
+        wc.goTo(aliceProjects.getUrl());
+
+        wc = r.createWebClient().login("bob", "bob");
+        try {
+            wc.goTo(aliceProjects.getUrl());
+            Assert.fail();
+        } catch (Exception expected) {
+            // expected
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
@@ -27,6 +27,7 @@ public class InheritanceMigrationTest {
 
         {
             Folder folder = (Folder) j.jenkins.getItemByFullName("folder");
+            Assert.assertTrue(folder.getConfigFile().asString().contains("blocksInheritance"));
             AuthorizationMatrixProperty prop = (folder).getProperties().get(AuthorizationMatrixProperty.class);
             Assert.assertTrue(prop.isBlocksInheritance());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
@@ -35,8 +36,11 @@ public class InheritanceMigrationTest {
             Assert.assertTrue(prop.hasExplicitPermission("admin", Item.CREATE));
             Assert.assertFalse(folder.getACL().hasPermission(User.get("alice").impersonate(), Item.READ));
             Assert.assertFalse(folder.getACL().hasPermission(User.get("bob").impersonate(), Item.READ));
+            folder.save();
+            Assert.assertFalse(folder.getConfigFile().asString().contains("blocksInheritance"));
 
             folder = (Folder) j.jenkins.getItemByFullName("folder1");
+            Assert.assertTrue(folder.getConfigFile().asString().contains("blocksInheritance"));
             prop = (folder).getProperties().get(AuthorizationMatrixProperty.class);
             Assert.assertTrue(prop.isBlocksInheritance());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
@@ -49,17 +53,23 @@ public class InheritanceMigrationTest {
             Assert.assertTrue(folder.getACL().hasPermission(User.get("alice").impersonate(), Item.READ));
             Assert.assertFalse(prop.hasPermission("bob", Item.READ));
             Assert.assertFalse(folder.getACL().hasPermission(User.get("bob").impersonate(), Item.READ));
+            folder.save();
+            Assert.assertFalse(folder.getConfigFile().asString().contains("blocksInheritance"));
         }
 
         {
             Job job = (Job) j.jenkins.getItemByFullName("folder/inheritNone");
+            Assert.assertTrue(job.getConfigFile().asString().contains("blocksInheritance"));
             hudson.security.AuthorizationMatrixProperty prop = (hudson.security.AuthorizationMatrixProperty) job.getProperty(hudson.security.AuthorizationMatrixProperty.class);
             Assert.assertTrue(prop.isBlocksInheritance());
             Assert.assertEquals(0, prop.getGrantedPermissions().size());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
             Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-24878/JENKINS-37904)
+            job.save();
+            Assert.assertFalse(job.getConfigFile().asString().contains("blocksInheritance"));
 
             job = (Job) j.jenkins.getItemByFullName("job");
+            Assert.assertTrue(job.getConfigFile().asString().contains("blocksInheritance"));
             prop = (hudson.security.AuthorizationMatrixProperty) job.getProperty(hudson.security.AuthorizationMatrixProperty.class);
             Assert.assertFalse(prop.isBlocksInheritance());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof InheritParentStrategy);
@@ -67,6 +77,8 @@ public class InheritanceMigrationTest {
             Assert.assertTrue(job.getACL().hasPermission(User.get("alice").impersonate(), Item.READ));
             Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.READ));
             Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.CONFIGURE));
+            job.save();
+            Assert.assertFalse(job.getConfigFile().asString().contains("blocksInheritance"));
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
@@ -42,7 +42,7 @@ public class InheritanceMigrationTest {
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
             Assert.assertTrue(prop.hasExplicitPermission("admin", Item.CONFIGURE));
             Assert.assertFalse(prop.hasExplicitPermission("admin", Item.READ));
-            Assert.assertTrue(folder.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-37904)
+            Assert.assertTrue(folder.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-24878/JENKINS-37904)
             Assert.assertTrue(folder.getACL().hasPermission(User.get("admin").impersonate(), Item.CONFIGURE));
             Assert.assertTrue(prop.hasExplicitPermission("alice", Item.CONFIGURE));
             Assert.assertTrue(prop.hasExplicitPermission("alice", Item.READ));
@@ -57,7 +57,7 @@ public class InheritanceMigrationTest {
             Assert.assertTrue(prop.isBlocksInheritance());
             Assert.assertEquals(0, prop.getGrantedPermissions().size());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
-            Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-37904)
+            Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-24878/JENKINS-37904)
 
             job = (Job) j.jenkins.getItemByFullName("job");
             prop = (hudson.security.AuthorizationMatrixProperty) job.getProperty(hudson.security.AuthorizationMatrixProperty.class);

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
@@ -1,0 +1,72 @@
+package org.jenkinsci.plugins.matrixauth.inheritance;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+public class InheritanceMigrationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @LocalData
+    public void testInheritanceMigration() throws Exception {
+        Assert.assertTrue(j.jenkins.getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy);
+        ProjectMatrixAuthorizationStrategy strategy = (ProjectMatrixAuthorizationStrategy) j.jenkins.getAuthorizationStrategy();
+
+        {
+            Folder folder = (Folder) j.jenkins.getItemByFullName("folder");
+            AuthorizationMatrixProperty prop = (folder).getProperties().get(AuthorizationMatrixProperty.class);
+            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
+            Assert.assertTrue(prop.hasExplicitPermission("admin", Item.CONFIGURE));
+            Assert.assertTrue(prop.hasExplicitPermission("admin", Item.READ));
+            Assert.assertTrue(prop.hasExplicitPermission("admin", Item.CREATE));
+            Assert.assertFalse(folder.getACL().hasPermission(User.get("alice").impersonate(), Item.READ));
+            Assert.assertFalse(folder.getACL().hasPermission(User.get("bob").impersonate(), Item.READ));
+
+            folder = (Folder) j.jenkins.getItemByFullName("folder1");
+            prop = (folder).getProperties().get(AuthorizationMatrixProperty.class);
+            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
+            Assert.assertTrue(prop.hasExplicitPermission("admin", Item.CONFIGURE));
+            Assert.assertFalse(prop.hasExplicitPermission("admin", Item.READ));
+            Assert.assertTrue(folder.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-37904)
+            Assert.assertTrue(folder.getACL().hasPermission(User.get("admin").impersonate(), Item.CONFIGURE));
+            Assert.assertTrue(prop.hasExplicitPermission("alice", Item.CONFIGURE));
+            Assert.assertTrue(prop.hasExplicitPermission("alice", Item.READ));
+            Assert.assertTrue(folder.getACL().hasPermission(User.get("alice").impersonate(), Item.READ));
+            Assert.assertFalse(prop.hasPermission("bob", Item.READ));
+            Assert.assertFalse(folder.getACL().hasPermission(User.get("bob").impersonate(), Item.READ));
+        }
+
+        {
+            Job job = (Job) j.jenkins.getItemByFullName("folder/inheritNone");
+            hudson.security.AuthorizationMatrixProperty prop = (hudson.security.AuthorizationMatrixProperty) job.getProperty(hudson.security.AuthorizationMatrixProperty.class);
+            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertEquals(0, prop.getGrantedPermissions().size());
+            Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
+            Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-37904)
+
+            job = (Job) j.jenkins.getItemByFullName("job");
+            prop = (hudson.security.AuthorizationMatrixProperty) job.getProperty(hudson.security.AuthorizationMatrixProperty.class);
+            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertTrue(prop.getInheritanceStrategy() instanceof InheritParentStrategy);
+            Assert.assertTrue(job.getACL().hasPermission(User.get("bob").impersonate(), Item.READ));
+            Assert.assertTrue(job.getACL().hasPermission(User.get("alice").impersonate(), Item.READ));
+            Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.READ));
+            Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.CONFIGURE));
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest.java
@@ -28,7 +28,7 @@ public class InheritanceMigrationTest {
         {
             Folder folder = (Folder) j.jenkins.getItemByFullName("folder");
             AuthorizationMatrixProperty prop = (folder).getProperties().get(AuthorizationMatrixProperty.class);
-            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertTrue(prop.isBlocksInheritance());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
             Assert.assertTrue(prop.hasExplicitPermission("admin", Item.CONFIGURE));
             Assert.assertTrue(prop.hasExplicitPermission("admin", Item.READ));
@@ -38,7 +38,7 @@ public class InheritanceMigrationTest {
 
             folder = (Folder) j.jenkins.getItemByFullName("folder1");
             prop = (folder).getProperties().get(AuthorizationMatrixProperty.class);
-            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertTrue(prop.isBlocksInheritance());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
             Assert.assertTrue(prop.hasExplicitPermission("admin", Item.CONFIGURE));
             Assert.assertFalse(prop.hasExplicitPermission("admin", Item.READ));
@@ -54,14 +54,14 @@ public class InheritanceMigrationTest {
         {
             Job job = (Job) j.jenkins.getItemByFullName("folder/inheritNone");
             hudson.security.AuthorizationMatrixProperty prop = (hudson.security.AuthorizationMatrixProperty) job.getProperty(hudson.security.AuthorizationMatrixProperty.class);
-            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertTrue(prop.isBlocksInheritance());
             Assert.assertEquals(0, prop.getGrantedPermissions().size());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof NonInheritingStrategy);
             Assert.assertTrue(job.getACL().hasPermission(User.get("admin").impersonate(), Item.READ)); // change from before (JENKINS-37904)
 
             job = (Job) j.jenkins.getItemByFullName("job");
             prop = (hudson.security.AuthorizationMatrixProperty) job.getProperty(hudson.security.AuthorizationMatrixProperty.class);
-            Assert.assertNull(prop.isBlocksInheritance());
+            Assert.assertFalse(prop.isBlocksInheritance());
             Assert.assertTrue(prop.getInheritanceStrategy() instanceof InheritParentStrategy);
             Assert.assertTrue(job.getACL().hasPermission(User.get("bob").impersonate(), Item.READ));
             Assert.assertTrue(job.getACL().hasPermission(User.get("alice").impersonate(), Item.READ));

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/config.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>2.0</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.ProjectMatrixAuthorizationStrategy">
+    <permission>hudson.model.Hudson.Administer:admin</permission>
+    <permission>hudson.model.Hudson.Read:alice</permission>
+    <permission>hudson.model.Hudson.Read:bob</permission>
+    <permission>hudson.model.Item.Read:alice</permission>
+  </authorizationStrategy>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>true</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+  </securityRealm>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>all</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>all</primaryView>
+  <slaveAgentPort>-1</slaveAgentPort>
+  <label></label>
+  <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+    <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+  </crumbIssuer>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/folder/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/folder/config.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.1.2">
+  <actions/>
+  <description></description>
+  <properties>
+    <com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+      <blocksInheritance>true</blocksInheritance>
+      <permission>hudson.model.Item.Read:admin</permission>
+      <permission>hudson.model.Item.Create:admin</permission>
+      <permission>hudson.model.Item.Configure:admin</permission>
+    </com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+  </properties>
+  <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+    <views>
+      <hudson.model.AllView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+    </views>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      <nonRecursive>false</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/folder/jobs/inheritNone/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/folder/jobs/inheritNone/config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.security.AuthorizationMatrixProperty>
+      <blocksInheritance>true</blocksInheritance>
+    </hudson.security.AuthorizationMatrixProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/folder1/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/folder1/config.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.1.2">
+  <actions/>
+  <description></description>
+  <properties>
+    <com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+      <blocksInheritance>true</blocksInheritance>
+      <permission>hudson.model.Item.Configure:alice</permission>
+      <permission>hudson.model.Item.Configure:admin</permission>
+      <permission>hudson.model.Item.Read:alice</permission>
+    </com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+  </properties>
+  <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+    <views>
+      <hudson.model.AllView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+    </views>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      <nonRecursive>false</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/job/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/jobs/job/config.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.security.AuthorizationMatrixProperty>
+      <blocksInheritance>false</blocksInheritance>
+      <permission>hudson.model.Item.Read:bob</permission>
+      <permission>hudson.model.Item.Configure:bob</permission>
+    </hudson.security.AuthorizationMatrixProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/users/admin/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/users/admin/config.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>admin</fullName>
+  <properties>
+    <jenkins.security.ApiTokenProperty>
+      <apiToken>{AQAAABAAAAAwGlr2GmbKMnWJDyTmXdB/J1yPDUj/A8tAFk8Sl7g7ZZIdEzMcatUYTgFQx2DqaKpGkQEV3V9vvLcGRIFkKLcbHg==}</apiToken>
+    </jenkins.security.ApiTokenProperty>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>all</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.model.PaneStatusProperties>
+      <collapsed/>
+    </hudson.model.PaneStatusProperties>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>true</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <passwordHash>#jbcrypt:$2a$10$8ikKOpe48MnWcKt4nIct6eY.DKVQhRqrlYx.fa.Mt7Ya1X9tFxMtS</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+  </properties>
+</user>

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/users/alice/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/users/alice/config.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>Alice</fullName>
+  <properties>
+    <jenkins.security.ApiTokenProperty>
+      <apiToken>{AQAAABAAAAAw++0Gifydu+kMl6DwWZxMyXeka/KVmOYbv6ljP7ljepmP4r7Q2oa04Z5Wp7WaOTEKxPfEgg2/v3ALLHn6J9SDKw==}</apiToken>
+    </jenkins.security.ApiTokenProperty>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>all</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.model.PaneStatusProperties>
+      <collapsed/>
+    </hudson.model.PaneStatusProperties>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>true</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <passwordHash>#jbcrypt:$2a$10$gcruH6YoDS/Sr0Yd9uSDdeqqZ9GidPEBPCKdzWCpDsdrNbQJwTAwC</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+  </properties>
+</user>

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/users/bob/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceMigrationTest/users/bob/config.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>Bob</fullName>
+  <properties>
+    <jenkins.security.ApiTokenProperty>
+      <apiToken>{AQAAABAAAAAwjQ/AtGDcImIkLDhq69pgnztzZq5jDwcRsZjwRnH+M/GunPrOxaLbCjBU1Xn1fRq1FHbmZXZV6klo0181L8HnSg==}</apiToken>
+    </jenkins.security.ApiTokenProperty>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>all</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.model.PaneStatusProperties>
+      <collapsed/>
+    </hudson.model.PaneStatusProperties>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>true</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <passwordHash>#jbcrypt:$2a$10$Q/.u9U7mphJ4q6Mfifa.Oufm6w4iUCs5TRHVLY/1m..kAqw0qGn.O</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+  </properties>
+</user>


### PR DESCRIPTION
I believe this addresses the following issues in [JENKINS-46834](https://issues.jenkins-ci.org/browse/JENKINS-46834):

* [JENKINS-39873](https://issues.jenkins-ci.org/browse/JENKINS-39873), 
* [JENKINS-37904](https://issues.jenkins-ci.org/browse/JENKINS-37904), 
* [JENKINS-39409](https://issues.jenkins-ci.org/browse/JENKINS-39409), 
* [JENKINS-38356](https://issues.jenkins-ci.org/browse/JENKINS-38356), 
* possibly [JENKINS-36788](https://issues.jenkins-ci.org/browse/JENKINS-36788), 
* [JENKINS-24878](https://issues.jenkins-ci.org/browse/JENKINS-24878) (sort of),

Incidentally as part of cleanup, [JENKINS-33315](https://issues.jenkins-ci.org/browse/JENKINS-33315) is also believed to be addressed.


Supersedes https://github.com/jenkinsci/matrix-auth-plugin/pull/15.

I may rewrite history.

![screen shot](https://user-images.githubusercontent.com/1831569/30346681-e125f122-9809-11e7-8bac-6a7b734fdb1e.png)


@jenkinsci/code-reviewers 