### PR TITLE
[JENKINS-46832] Prevent initial misconfiguration by making sure there's an admin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>2.29</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>1.8-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.29</version>
+        <version>2.33</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>1.8-SNAPSHOT</version>

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -32,7 +32,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.PluginManager;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Descriptor;
-import hudson.model.Failure;
 import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
 import hudson.model.Item;
@@ -412,15 +411,17 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
                 }
             }
 
-            if (gmas.grantedPermissions.size() == 0) {
-                throw new Failure("Refusing to save authorization strategy that does not provide any permissions globally.");
+            if (!adminAdded) {
+                User current = User.current();
+                String id;
+                if (current == null) {
+                    id = "anonymous";
+                } else {
+                    id = current.getId();
+                }
+                gmas.add(Jenkins.ADMINISTER, id);
             }
 
-            // SecurityRealm is set before this is called by GlobalSecurityConfiguration in core, so this works.
-            SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
-            if (!adminAdded && !securityRealm.allowsSignup() && User.getAll().size() > 0) {
-                throw new Failure("Refusing to save authorization strategy without any administrators when the security realm doesn't allow signup and there are users.");
-            }
             return gmas;
         }
 

--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -1,0 +1,73 @@
+package hudson.security;
+
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlLabel;
+import hudson.model.User;
+import jenkins.model.Jenkins;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ProjectMatrixAuthorizationStrategyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void submitEmptyPropertyEnsuresPermissionsForSubmitter() throws Exception {
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        realm.createAccount("alice","alice");
+        realm.createAccount("bob","bob");
+        r.jenkins.setSecurityRealm(realm);
+
+        r.jenkins.setAuthorizationStrategy(new FullControlOnceLoggedInAuthorizationStrategy());
+
+        // ensure logged in users are admins, but anon is not
+        try (ACLContext _ = ACL.as(User.get("alice"))) {
+            Assert.assertTrue("alice is admin", r.jenkins.hasPermission(Jenkins.ADMINISTER));
+        }
+        try (ACLContext _ = ACL.as(User.get("bob"))) {
+            Assert.assertTrue("bob is admin", r.jenkins.hasPermission(Jenkins.ADMINISTER));
+        }
+        Assert.assertFalse("anon is not admin", r.jenkins.getACL().hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));
+
+        JenkinsRule.WebClient wc = r.createWebClient().login("alice");
+        HtmlForm form = wc.goTo("configureSecurity").getFormByName("config");
+
+        // TODO this must be possible in a nicer way
+        HtmlElement label = form.getElementsByTagName("label").stream().filter(lbl -> lbl.asText().contains("Matrix-based security")).findAny().get();
+        ((HtmlLabel)label).click();
+        r.submit(form);
+
+        try (ACLContext _ = ACL.as(User.get("alice"))) {
+            // ensure that the user submitting the empty matrix will be admin
+            Assert.assertTrue("alice is admin", r.jenkins.hasPermission(Jenkins.ADMINISTER));
+        }
+        try (ACLContext _ = ACL.as(User.get("bob"))) {
+            Assert.assertFalse("bob is not admin", r.jenkins.hasPermission(Jenkins.ADMINISTER));
+        }
+        Assert.assertFalse("anon is not admin", r.jenkins.getACL().hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));
+    }
+
+    @Test
+    public void submitEmptyPropertyEnsuresPermissionsForAnonymousSubmitter() throws Exception {
+        // prepare form to have options visible
+        r.jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(true));
+        r.jenkins.setAuthorizationStrategy(new AuthorizationStrategy.Unsecured());
+
+        Assert.assertTrue("anon is admin", r.jenkins.getACL().hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));
+
+        JenkinsRule.WebClient wc = r.createWebClient();
+        HtmlForm form = wc.goTo("configureSecurity").getFormByName("config");
+
+        // TODO this must be possible in a nicer way
+        HtmlElement label = form.getElementsByTagName("label").stream().filter(lbl -> lbl.asText().contains("Matrix-based security")).findAny().get();
+        ((HtmlLabel)label).click();
+        r.submit(form);
+
+        Assert.assertTrue("anon is admin", r.jenkins.getACL().hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));
+        Assert.assertTrue(r.jenkins.getAuthorizationStrategy() instanceof GlobalMatrixAuthorizationStrategy);
+    }
+}

--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -37,7 +37,8 @@ public class ProjectMatrixAuthorizationStrategyTest {
         HtmlForm form = wc.goTo("configureSecurity").getFormByName("config");
 
         // TODO this must be possible in a nicer way
-        HtmlElement label = form.getElementsByTagName("label").stream().filter(lbl -> lbl.asText().contains("Matrix-based security")).findAny().get();
+        HtmlElement label = form.getElementsByTagName("label").stream().filter(
+                lbl -> lbl.asText().contains(GlobalMatrixAuthorizationStrategy.DESCRIPTOR.getDisplayName())).findAny().get();
         ((HtmlLabel)label).click();
         r.submit(form);
 
@@ -63,7 +64,8 @@ public class ProjectMatrixAuthorizationStrategyTest {
         HtmlForm form = wc.goTo("configureSecurity").getFormByName("config");
 
         // TODO this must be possible in a nicer way
-        HtmlElement label = form.getElementsByTagName("label").stream().filter(lbl -> lbl.asText().contains("Matrix-based security")).findAny().get();
+        HtmlElement label = form.getElementsByTagName("label").stream().filter(
+                lbl -> lbl.asText().contains(GlobalMatrixAuthorizationStrategy.DESCRIPTOR.getDisplayName())).findAny().get();
         ((HtmlLabel)label).click();
         r.submit(form);
 


### PR DESCRIPTION
This is a pretty crude approach to attempt to prevent the problem, but I'm not sure with the current form there can be a better one.

This addresses part of [JENKINS-9774](https://issues.jenkins-ci.org/browse/JENKINS-9774) by preventing accidentally empty global permissions overall (but not the parse problem -- that's handled by https://github.com/jenkinsci/matrix-auth-plugin/pull/25), and part of [JENKINS-10871](https://issues.jenkins-ci.org/browse/JENKINS-10871) by ensuring there's an admin that can log in (or, in the worst case, anonymous).

While the UX of [JENKINS-28668](https://issues.jenkins-ci.org/browse/JENKINS-28668) remains terrible, this change will prevent such accidental lockouts as well.

The current approach will result in anonymous users being granted admin permissions in many cases, instead of just saving a broken configuration resulting in lock-out. This should still be preferable to just locking out users, and should be pretty obvious when browsing Jenkins as well.

@jenkinsci/code-reviewers 