### PR TITLE
[JENKINS-9774] Drop support for pre-2009 serialized format that resulted in errors

### DIFF
--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -134,26 +134,10 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     };
 
     public static class ConverterImpl extends GlobalMatrixAuthorizationStrategy.ConverterImpl {
-        private RobustReflectionConverter ref;
-
-        public ConverterImpl(Mapper m) {
-            ref = new RobustReflectionConverter(m,JVM.newReflectionProvider());
-        }
 
         @Override
         protected GlobalMatrixAuthorizationStrategy create() {
             return new ProjectMatrixAuthorizationStrategy();
-        }
-
-        @Override
-        public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
-            String name = reader.peekNextChild();
-            if(name!=null && (name.equals("permission") || name.equals("useProjectSecurity")))
-                // the proper serialization form
-                return super.unmarshal(reader, context);
-            else
-                // remain compatible with earlier problem where we used reflection converter
-                return ref.unmarshal(reader,context);
         }
 
         @Override

--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -80,4 +80,16 @@ public class ProjectMatrixAuthorizationStrategyTest {
         Assert.assertTrue(r.jenkins.getSecurityRealm() instanceof HudsonPrivateSecurityRealm);
         Assert.assertTrue(r.jenkins.getAuthorizationStrategy() instanceof GlobalMatrixAuthorizationStrategy);
     }
+
+    @Test
+    @LocalData
+    public void loadFilledAuthorizationStrategy() throws Exception {
+        Assert.assertTrue(r.jenkins.getSecurityRealm() instanceof HudsonPrivateSecurityRealm);
+        Assert.assertTrue(r.jenkins.getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy);
+
+        ProjectMatrixAuthorizationStrategy authorizationStrategy = (ProjectMatrixAuthorizationStrategy) r.jenkins.getAuthorizationStrategy();
+        Assert.assertTrue(authorizationStrategy.hasExplicitPermission("alice", Jenkins.ADMINISTER));
+        Assert.assertFalse(authorizationStrategy.hasExplicitPermission("alice", Jenkins.READ));
+        Assert.assertFalse(authorizationStrategy.hasExplicitPermission("bob", Jenkins.ADMINISTER));
+    }
 }

--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 public class ProjectMatrixAuthorizationStrategyTest {
 
@@ -70,6 +71,13 @@ public class ProjectMatrixAuthorizationStrategyTest {
         r.submit(form);
 
         Assert.assertTrue("anon is admin", r.jenkins.getACL().hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));
+        Assert.assertTrue(r.jenkins.getAuthorizationStrategy() instanceof GlobalMatrixAuthorizationStrategy);
+    }
+
+    @Test
+    @LocalData
+    public void loadEmptyAuthorizationStrategy() throws Exception {
+        Assert.assertTrue(r.jenkins.getSecurityRealm() instanceof HudsonPrivateSecurityRealm);
         Assert.assertTrue(r.jenkins.getAuthorizationStrategy() instanceof GlobalMatrixAuthorizationStrategy);
     }
 }

--- a/src/test/resources/hudson/security/ProjectMatrixAuthorizationStrategyTest/loadEmptyAuthorizationStrategy/config.xml
+++ b/src/test/resources/hudson/security/ProjectMatrixAuthorizationStrategyTest/loadEmptyAuthorizationStrategy/config.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+    <disabledAdministrativeMonitors/>
+    <version>1.0</version>
+    <numExecutors>2</numExecutors>
+    <mode>NORMAL</mode>
+    <useSecurity>true</useSecurity>
+    <authorizationStrategy class="hudson.security.ProjectMatrixAuthorizationStrategy"/>
+    <securityRealm class="hudson.security.HudsonPrivateSecurityRealm"/>
+    <disableRememberMe>false</disableRememberMe>
+    <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+    <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+    <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+    <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+    <jdks/>
+    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+    <clouds/>
+    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+    <views>
+        <hudson.model.AllView>
+            <owner class="hudson" reference="../../.."/>
+            <name>all</name>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+    </views>
+    <primaryView>all</primaryView>
+    <slaveAgentPort>0</slaveAgentPort>
+    <label></label>
+    <nodeProperties/>
+    <globalNodeProperties/>
+</hudson>

--- a/src/test/resources/hudson/security/ProjectMatrixAuthorizationStrategyTest/loadFilledAuthorizationStrategy/config.xml
+++ b/src/test/resources/hudson/security/ProjectMatrixAuthorizationStrategyTest/loadFilledAuthorizationStrategy/config.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+    <disabledAdministrativeMonitors/>
+    <version>1.0</version>
+    <numExecutors>2</numExecutors>
+    <mode>NORMAL</mode>
+    <useSecurity>true</useSecurity>
+    <authorizationStrategy class="hudson.security.ProjectMatrixAuthorizationStrategy">
+        <permission>hudson.model.Hudson.Administer:alice</permission>
+    </authorizationStrategy>
+    <securityRealm class="hudson.security.HudsonPrivateSecurityRealm"/>
+    <disableRememberMe>false</disableRememberMe>
+    <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+    <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+    <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+    <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+    <jdks/>
+    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+    <clouds/>
+    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+    <views>
+        <hudson.model.AllView>
+            <owner class="hudson" reference="../../.."/>
+            <name>all</name>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+    </views>
+    <primaryView>all</primaryView>
+    <slaveAgentPort>0</slaveAgentPort>
+    <label></label>
+    <nodeProperties/>
+    <globalNodeProperties/>
+</hudson>


### PR DESCRIPTION
I doubt anyone still cares a lot about reading configurations written before https://github.com/jenkinsci/jenkins/commit/27f8c5a67622f27d580c2c7c4cc53d7dec77fd01

OTOH, [JENKINS-9774](https://issues.jenkins-ci.org/browse/JENKINS-9774) should be resolved (sort of). Nobody has permissions, but at least it won't break Jenkins complete.

Complements https://github.com/jenkinsci/matrix-auth-plugin/pull/24