### PR TITLE
[FIX JENKINS-14563] Show full name of user instead of user name

### DIFF
--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -30,6 +30,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.PluginManager;
+import hudson.Util;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Descriptor;
 import jenkins.model.IdStrategy;
@@ -47,6 +48,7 @@ import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.acls.sid.PrincipalSid;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.acegisecurity.acls.sid.Sid;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.matrixauth.Messages;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -482,7 +484,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
                     if (ev.equals(u.getFullName())) {
                         return FormValidation.respond(Kind.OK, makeImg("person.png", ev, "User", false));
                     }
-                    return FormValidation.respond(Kind.OK, makeImg("person.png", u.getFullName(), "User " + ev, false));
+                    return FormValidation.respond(Kind.OK, makeImg("person.png", Util.escape(StringUtils.abbreviate(u.getFullName(), 50)), "User " + ev, false));
                 } catch (UserMayOrMayNotExistException e) {
                     // undecidable, meaning the user may exist
                     return FormValidation.respond(Kind.OK, ev);

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -473,12 +473,16 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
 
             if(v.equals("authenticated"))
                 // system reserved group
-                return FormValidation.respond(Kind.OK, makeImg("user.png", "Group", false) +ev);
+                return FormValidation.respond(Kind.OK, makeImg("user.png", ev, "Group", false));
 
             try {
                 try {
                     sr.loadUserByUsername(v);
-                    return FormValidation.respond(Kind.OK, makeImg("person.png", "User", false)+ev);
+                    User u = User.get(v);
+                    if (ev.equals(u.getFullName())) {
+                        return FormValidation.respond(Kind.OK, makeImg("person.png", ev, "User", false));
+                    }
+                    return FormValidation.respond(Kind.OK, makeImg("person.png", u.getFullName(), "User " + ev, false));
                 } catch (UserMayOrMayNotExistException e) {
                     // undecidable, meaning the user may exist
                     return FormValidation.respond(Kind.OK, ev);
@@ -493,7 +497,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
 
                 try {
                     sr.loadGroupByGroupname(v);
-                    return FormValidation.respond(Kind.OK, makeImg("user.png", "Group", false) +ev);
+                    return FormValidation.respond(Kind.OK, makeImg("user.png", ev, "Group", false));
                 } catch (UserMayOrMayNotExistException e) {
                     // undecidable, meaning the group may exist
                     return FormValidation.respond(Kind.OK, ev);
@@ -507,7 +511,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
                 }
 
                 // couldn't find it. it doesn't exist
-                return FormValidation.respond(Kind.ERROR, makeImg("user-disabled.png", "User or group not found", true) + formatNonexistentUser(ev));
+                return FormValidation.respond(Kind.ERROR, makeImg("user-disabled.png", formatNonexistentUser(ev), "User or group not found", true));
             } catch (Exception e) {
                 // if the check fails miserably, we still want the user to be able to see the name of the user,
                 // so use 'ev' as the message
@@ -519,11 +523,11 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy {
             return "<span style='text-decoration: line-through; color: grey;'>" + username + "</span>";
         }
 
-        private String makeImg(String img, String tooltip, boolean inPlugin) {
+        private String makeImg(String img, String label, String tooltip, boolean inPlugin) {
             if (inPlugin) {
-                return String.format("<img src='%s/plugin/matrix-auth/images/%s' title='%s' style='margin-right:0.2em'>", Stapler.getCurrentRequest().getContextPath(), img, tooltip);
+                return String.format("<span title='%s'><img src='%s/plugin/matrix-auth/images/%s' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), img, label);
             } else {
-                return String.format("<img src='%s%s/images/16x16/%s' title='%s' style='margin-right:0.2em'>", Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, img, tooltip);
+                return String.format("<span title='%s'><img src='%s%s/images/16x16/%s' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, img, label);
             }
         }
     }


### PR DESCRIPTION
For users that have a "full name" different from their user ID, this will show the full name, with the user ID available as tool tip.

![screen shot](https://user-images.githubusercontent.com/1831569/30420690-adac3054-993a-11e7-9750-7173a7e39dbe.png)

@jenkinsci/code-reviewers mostly to get opinions on usefulness / possible unintended side effects