### PR TITLE
Various improvements towards 2.0

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -26,10 +26,10 @@ package com.cloudbees.hudson.plugins.folder.properties;
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractItem;
 import hudson.model.Item;
-import hudson.model.Job;
 import hudson.model.User;
 import hudson.model.listeners.ItemListener;
 import hudson.security.AuthorizationStrategy;
@@ -51,7 +51,6 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,7 +64,7 @@ import java.util.Set;
  */
 public class AuthorizationMatrixProperty extends AbstractFolderProperty<AbstractFolder<?>> implements AuthorizationProperty {
 
-    private transient SidACL acl = new AclImpl();
+    private final transient SidACL acl = new AclImpl();
 
     /**
      * List up all permissions that are granted.
@@ -73,9 +72,9 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
      * Strings are either the granted authority or the principal, which is not
      * distinguished.
      */
-    private final Map<Permission, Set<String>> grantedPermissions = new HashMap<Permission, Set<String>>();
+    private final Map<Permission, Set<String>> grantedPermissions = new HashMap<>();
 
-    private Set<String> sids = new HashSet<String>();
+    private final Set<String> sids = new HashSet<>();
 
     private boolean blocksInheritance = false;
 
@@ -85,7 +84,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
     public AuthorizationMatrixProperty(Map<Permission,? extends Set<String>> grantedPermissions) {
         // do a deep copy to be safe
         for (Entry<Permission,? extends Set<String>> e : grantedPermissions.entrySet())
-            this.grantedPermissions.put(e.getKey(),new HashSet<String>(e.getValue()));
+            this.grantedPermissions.put(e.getKey(),new HashSet<>(e.getValue()));
     }
 
     public Set<String> getGroups() {
@@ -110,7 +109,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
     public void add(Permission p, String sid) {
         Set<String> set = grantedPermissions.get(p);
         if (set == null)
-            grantedPermissions.put(p, set = new HashSet<String>());
+            grantedPermissions.put(p, set = new HashSet<>());
         set.add(sid);
         sids.add(sid);
     }
@@ -138,18 +137,13 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
             return isApplicable();
         }
 
-        @Override
-        public String getDisplayName() {
-            return "Authorization Matrix";
-        }
-
-        public FormValidation doCheckName(@AncestorInPath AbstractFolder<?> folder, @QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckName(@AncestorInPath AbstractFolder<?> folder, @QueryParameter String value) {
             return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value, folder, Item.CONFIGURE);
         }
     }
 
     private final class AclImpl extends SidACL {
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "NP_BOOLEAN_RETURN_NULL",
+        @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL",
                 justification = "Because that is the way this SPI works")
         protected Boolean hasPermission(Sid sid, Permission p) {
             if (AuthorizationMatrixProperty.this.hasPermission(toString(sid),p))
@@ -165,7 +159,6 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
     /**
      * Sets the flag to block inheritance
      *
-     * @param blocksInheritance
      */
     public void setBlocksInheritance(boolean blocksInheritance) {
         this.blocksInheritance = blocksInheritance;
@@ -175,7 +168,6 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
      * Returns true if the authorization matrix is configured to block
      * inheritance from the parent.
      *
-     * @return
      */
     public boolean isBlocksInheritance() {
         return this.blocksInheritance;

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -197,16 +197,6 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 		public AuthorizationProperty createSubject() {
 		    return new AuthorizationMatrixProperty();
         }
-
-		public Object unmarshal(HierarchicalStreamReader reader,
-				final UnmarshallingContext context) {
-			Object o = super.unmarshal(reader, context);
-
-            if (GlobalMatrixAuthorizationStrategy.migrateHudson2324(((AuthorizationMatrixProperty)o).grantedPermissions))
-                OldDataMonitor.report(context, "1.301");
-
-            return o;
-        }
     }
 
 	/**

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -23,11 +23,8 @@
  */
 package hudson.security;
 
-import com.thoughtworks.xstream.converters.UnmarshallingContext;
-import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
-import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.JobProperty;
@@ -44,7 +41,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.CheckForNull;
-import javax.servlet.ServletException;
 
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -67,7 +63,7 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implements AuthorizationProperty {
 
-	private transient SidACL acl = new AclImpl();
+	private final transient SidACL acl = new AclImpl();
 
 	/**
 	 * List up all permissions that are granted.
@@ -75,9 +71,9 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	 * Strings are either the granted authority or the principal, which is not
 	 * distinguished.
 	 */
-	private final Map<Permission, Set<String>> grantedPermissions = new HashMap<Permission, Set<String>>();
+	private final Map<Permission, Set<String>> grantedPermissions = new HashMap<>();
 
-	private Set<String> sids = new HashSet<String>();
+	private final Set<String> sids = new HashSet<>();
 
     private boolean blocksInheritance = false;
 
@@ -87,7 +83,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
     public AuthorizationMatrixProperty(Map<Permission, Set<String>> grantedPermissions) {
         // do a deep copy to be safe
         for (Entry<Permission,Set<String>> e : grantedPermissions.entrySet())
-            this.grantedPermissions.put(e.getKey(),new HashSet<String>(e.getValue()));
+            this.grantedPermissions.put(e.getKey(),new HashSet<>(e.getValue()));
     }
 
 	public Set<String> getGroups() {
@@ -112,7 +108,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	public void add(Permission p, String sid) {
 		Set<String> set = grantedPermissions.get(p);
 		if (set == null)
-			grantedPermissions.put(p, set = new HashSet<String>());
+			grantedPermissions.put(p, set = new HashSet<>());
 		set.add(sid);
 		sids.add(sid);
 	}
@@ -140,12 +136,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
             return isApplicable();
 		}
 
-		@Override
-		public String getDisplayName() {
-			return "Authorization Matrix";
-		}
-
-        public FormValidation doCheckName(@AncestorInPath Job project, @QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckName(@AncestorInPath Job project, @QueryParameter String value) {
             return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value, project, Item.CONFIGURE);
         }
     }
@@ -169,7 +160,6 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	/**
 	 * Sets the flag to block inheritance
 	 *
-	 * @param blocksInheritance
 	 */
 	public void setBlocksInheritance(boolean blocksInheritance) {
 		this.blocksInheritance = blocksInheritance;
@@ -179,7 +169,6 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	 * Returns true if the authorization matrix is configured to block
 	 * inheritance from the parent.
 	 *
-	 * @return
 	 */
 	public boolean isBlocksInheritance() {
 		return this.blocksInheritance;

--- a/src/main/java/hudson/security/DangerousMatrixPermissionsAdministrativeMonitor.java
+++ b/src/main/java/hudson/security/DangerousMatrixPermissionsAdministrativeMonitor.java
@@ -33,7 +33,6 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +46,7 @@ public class DangerousMatrixPermissionsAdministrativeMonitor extends Administrat
     }
 
     @RequirePOST
-    public HttpResponse doAct(@QueryParameter String yes) throws IOException {
+    public HttpResponse doAct(@QueryParameter String yes) {
         if (yes != null) {
             return HttpResponses.redirectViaContextPath("configureSecurity");
         }
@@ -61,11 +60,11 @@ public class DangerousMatrixPermissionsAdministrativeMonitor extends Administrat
             return Collections.emptyList();
         }
 
-        List<String> sids = new ArrayList<String>();
+        List<String> sids = new ArrayList<>();
 
         GlobalMatrixAuthorizationStrategy strategy = (GlobalMatrixAuthorizationStrategy) j.getAuthorizationStrategy();
 
-        List<String> allSidsPlusAnon = new ArrayList<String>(strategy.getAllSIDs());
+        List<String> allSidsPlusAnon = new ArrayList<>(strategy.getAllSIDs());
         allSidsPlusAnon.add("anonymous");
 
         for (String sid : allSidsPlusAnon) {

--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -31,12 +31,7 @@ import jenkins.model.Jenkins;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
-import hudson.util.RobustReflectionConverter;
 import hudson.Extension;
-import com.thoughtworks.xstream.io.HierarchicalStreamReader;
-import com.thoughtworks.xstream.converters.UnmarshallingContext;
-import com.thoughtworks.xstream.mapper.Mapper;
-import com.thoughtworks.xstream.core.JVM;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.matrixauth.AuthorizationMatrixNodeProperty;
 import org.jenkinsci.plugins.matrixauth.Messages;
@@ -55,7 +50,8 @@ import java.util.TreeSet;
  */
 public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizationStrategy {
     @Override
-    public ACL getACL(Job<?,?> project) {
+    @Nonnull
+    public ACL getACL(@Nonnull Job<?,?> project) {
         AuthorizationMatrixProperty amp = project.getProperty(AuthorizationMatrixProperty.class);
         if (amp != null) {
             SidACL projectAcl = amp.getACL();
@@ -77,7 +73,7 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
         }
         return new ACL() {
             @Override
-            public boolean hasPermission(Authentication a, Permission permission) {
+            public boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission permission) {
                 return child.hasPermission(a, permission) || parent.hasPermission(a, permission);
             }
         };
@@ -92,7 +88,8 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     }
 
     @Override
-    public ACL getACL(AbstractItem item) {
+    @Nonnull
+    public ACL getACL(@Nonnull AbstractItem item) {
         if (Jenkins.getInstance().getPlugin("cloudbees-folder") != null) { // optional dependency
             if (item instanceof AbstractFolder) {
                 com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty p = (com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty) ((AbstractFolder) item).getProperties().get(com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty.class);
@@ -129,8 +126,9 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     }
 
     @Override
+    @Nonnull
     public Set<String> getGroups() {
-        Set<String> r = new TreeSet<String>(new IdStrategyComparator());
+        Set<String> r = new TreeSet<>(new IdStrategyComparator());
         r.addAll(super.getGroups());
         for (Job<?,?> j : Jenkins.getInstance().getAllItems(Job.class)) {
             AuthorizationMatrixProperty jobProperty = j.getProperty(AuthorizationMatrixProperty.class);
@@ -159,6 +157,7 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
         }
 
         @Override
+        @Nonnull
         public String getDisplayName() {
             return Messages.ProjectMatrixAuthorizationStrategy_DisplayName();
         }

--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -93,7 +93,7 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
 
     @Override
     public ACL getACL(AbstractItem item) {
-        if (Jenkins.getActiveInstance().getPlugin("cloudbees-folder") != null) { // optional dependency
+        if (Jenkins.getInstance().getPlugin("cloudbees-folder") != null) { // optional dependency
             if (item instanceof AbstractFolder) {
                 com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty p = (com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty) ((AbstractFolder) item).getProperties().get(com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty.class);
                 if (p != null) {
@@ -132,10 +132,21 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     public Set<String> getGroups() {
         Set<String> r = new TreeSet<String>(new IdStrategyComparator());
         r.addAll(super.getGroups());
-        for (Job<?,?> j : Jenkins.getActiveInstance().getItems(Job.class)) {
-            AuthorizationMatrixProperty amp = j.getProperty(AuthorizationMatrixProperty.class);
-            if (amp != null)
-                r.addAll(amp.getGroups());
+        for (Job<?,?> j : Jenkins.getInstance().getAllItems(Job.class)) {
+            AuthorizationMatrixProperty jobProperty = j.getProperty(AuthorizationMatrixProperty.class);
+            if (jobProperty != null)
+                r.addAll(jobProperty.getGroups());
+        }
+        for (AbstractFolder<?> j : Jenkins.getInstance().getAllItems(AbstractFolder.class)) {
+            com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty folderProperty = j.getProperties().get(com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty.class);
+            if (folderProperty != null)
+                r.addAll(folderProperty.getGroups());
+        }
+        for (Node node : Jenkins.getInstance().getNodes()) {
+            AuthorizationMatrixNodeProperty nodeProperty = node.getNodeProperty(AuthorizationMatrixNodeProperty.class);
+            if (nodeProperty != null) {
+                r.addAll(nodeProperty.getGroups());
+            }
         }
         return r;
     }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractMatrixPropertyConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractMatrixPropertyConverter.java
@@ -31,12 +31,15 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import hudson.security.AuthorizationMatrixProperty;
 import hudson.security.Permission;
 import hudson.util.RobustReflectionConverter;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+@Restricted(NoExternalUse.class)
 public abstract class AbstractMatrixPropertyConverter implements Converter {
     abstract public boolean canConvert(Class type);
 

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -50,7 +50,6 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,11 +59,11 @@ import java.util.Set;
 
 public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implements AuthorizationProperty {
 
-    private transient SidACL acl = new AclImpl();
+    private final transient SidACL acl = new AclImpl();
 
-    private final Map<Permission, Set<String>> grantedPermissions = new HashMap<Permission, Set<String>>();
+    private final Map<Permission, Set<String>> grantedPermissions = new HashMap<>();
 
-    private Set<String> sids = new HashSet<String>();
+    private final Set<String> sids = new HashSet<>();
 
     private boolean blocksInheritance = false;
 
@@ -74,7 +73,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
     public AuthorizationMatrixNodeProperty(Map<Permission, Set<String>> grantedPermissions) {
         // do a deep copy to be safe
         for (Map.Entry<Permission,Set<String>> e : grantedPermissions.entrySet())
-            this.grantedPermissions.put(e.getKey(),new HashSet<String>(e.getValue()));
+            this.grantedPermissions.put(e.getKey(),new HashSet<>(e.getValue()));
     }
 
     public Set<String> getGroups() {
@@ -99,7 +98,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
     public void add(Permission p, String sid) {
         Set<String> set = grantedPermissions.get(p);
         if (set == null)
-            grantedPermissions.put(p, set = new HashSet<String>());
+            grantedPermissions.put(p, set = new HashSet<>());
         set.add(sid);
         sids.add(sid);
     }
@@ -158,7 +157,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
         }
 
         @Override
-        public AuthorizationMatrixNodeProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public AuthorizationMatrixNodeProperty newInstance(StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
             return createNewInstance(req, formData, false);
         }
 
@@ -167,12 +166,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
             return isApplicable();
         }
 
-        @Override
-        public String getDisplayName() {
-            return "Authorization Matrix";
-        }
-
-        public FormValidation doCheckName(@AncestorInPath Computer computer, @QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckName(@AncestorInPath Computer computer, @QueryParameter String value) {
             // TODO Computer needs to become a DescriptorByNameOwner for the AncestorInPath to work
             return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value,
                     computer == null ? Jenkins.getInstance() : computer,

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixPropertyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixPropertyDescriptor.java
@@ -23,7 +23,6 @@
  */
 package org.jenkinsci.plugins.matrixauth;
 
-import hudson.model.Descriptor;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
@@ -32,6 +31,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +43,7 @@ public interface AuthorizationMatrixPropertyDescriptor<T extends AuthorizationPr
 
     PermissionScope getPermissionScope();
 
-    default T createNewInstance(StaplerRequest req, JSONObject formData, boolean hasOptionalWrap) throws Descriptor.FormException {
+    default T createNewInstance(StaplerRequest req, JSONObject formData, boolean hasOptionalWrap) {
         if (hasOptionalWrap) {
             formData = formData.getJSONObject("useProjectSecurity");
             if (formData.isNullObject())
@@ -79,12 +79,13 @@ public interface AuthorizationMatrixPropertyDescriptor<T extends AuthorizationPr
         }
     }
 
+    @Nonnull
     default String getDisplayName() {
-        return "Authorization Matrix";
+        return "Authorization Matrix"; // TODO i18n
     }
 
     default List<PermissionGroup> getAllGroups() {
-        List<PermissionGroup> groups = new ArrayList<PermissionGroup>();
+        List<PermissionGroup> groups = new ArrayList<>();
         for (PermissionGroup g : PermissionGroup.getAll()) {
             if (g.hasPermissionContainedBy(getPermissionScope())) {
                 groups.add(g);

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -134,7 +134,7 @@ public interface AuthorizationProperty {
      * @return Always non-null.
      */
     default List<String> getAllSIDs() {
-        Set<String> r = new TreeSet<String>(new GlobalMatrixAuthorizationStrategy.IdStrategyComparator());
+        Set<String> r = new TreeSet<>(new GlobalMatrixAuthorizationStrategy.IdStrategyComparator());
         for (Set<String> set : getGrantedPermissions().values())
             r.addAll(set);
         r.remove("anonymous");

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -103,7 +103,7 @@ public interface AuthorizationProperty {
         if (set != null && p.getEnabled()) {
             if (set.contains(sid))
                 return true;
-            final SecurityRealm securityRealm = Jenkins.getActiveInstance().getSecurityRealm();
+            final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
             final IdStrategy groupIdStrategy = securityRealm.getGroupIdStrategy();
             final IdStrategy userIdStrategy = securityRealm.getUserIdStrategy();
             for (String s: set) {

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty/config.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
     <f:nested>
       <table style="width:100%">

--- a/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
+++ b/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
     <f:nested>
       <table style="width:100%">

--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form">
   <f:block xmlns:local="local">
     <j:set var="groups" value="${descriptor.allGroups}"/>
     <d:taglib uri="local">

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty/config.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <f:nested>
         <table style="width:100%">
             <f:optionalBlock field="blocksInheritance"

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
@@ -51,7 +51,7 @@ public class AuthorizationMatrixPropertyTest {
 
     @Test
     public void ensureCreatorHasPermissions() throws Exception {
-        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false, false, null);
         realm.createAccount("alice","alice");
         realm.createAccount("bob","bob");
         r.jenkins.setSecurityRealm(realm);
@@ -73,7 +73,7 @@ public class AuthorizationMatrixPropertyTest {
     }
 
     @Test public void basics1() throws Exception {
-        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false, false, null);
         realm.createAccount("alice","alice");
         realm.createAccount("bob","bob");
         r.jenkins.setSecurityRealm(realm);
@@ -120,7 +120,7 @@ public class AuthorizationMatrixPropertyTest {
     }
 
     @Test public void disabling_permission_inheritance_removes_global_permissions() throws Exception {
-        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false, false, null);
         realm.createAccount("alice","alice");
         realm.createAccount("bob","bob");
         r.jenkins.setSecurityRealm(realm);

--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -20,7 +20,7 @@ public class ProjectMatrixAuthorizationStrategyTest {
 
     @Test
     public void ensureCreatorHasPermissions() throws Exception {
-        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false, false, null);
         realm.createAccount("alice","alice");
         realm.createAccount("bob","bob");
         r.jenkins.setSecurityRealm(realm);
@@ -44,7 +44,7 @@ public class ProjectMatrixAuthorizationStrategyTest {
 
     @Test
     public void submitEmptyPropertyEnsuresPermissionsForSubmitter() throws Exception {
-        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false, false, null);
         realm.createAccount("alice","alice");
         realm.createAccount("bob","bob");
         r.jenkins.setSecurityRealm(realm);
@@ -82,7 +82,7 @@ public class ProjectMatrixAuthorizationStrategyTest {
     @Test
     public void submitEmptyPropertyEnsuresPermissionsForAnonymousSubmitter() throws Exception {
         // prepare form to have options visible
-        r.jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(true));
+        r.jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(true, false, null));
         r.jenkins.setAuthorizationStrategy(new AuthorizationStrategy.Unsecured());
 
         Assert.assertTrue("anon is admin", r.jenkins.getACL().hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodePropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodePropertyTest.java
@@ -44,7 +44,7 @@ public class AuthorizationMatrixNodePropertyTest {
 
     @Test
     public void ensureCreatorHasPermissions() throws Exception {
-        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false, false, null);
         realm.createAccount("alice","alice");
         realm.createAccount("bob","bob");
         r.jenkins.setSecurityRealm(realm);

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
@@ -27,7 +27,7 @@ public class PermissionAdderTest {
         r.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                r.j.jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(true));
+                r.j.jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(true, false, null));
                 r.j.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
                 r.j.jenkins.save();
 


### PR DESCRIPTION
- Drop 1.301 permission backward compatibility code (it's been more than 8 years…)
- Remove deprecated Jenkins#getActiveInstance calls
- Proper implementation of getGroups() in project-based matrix