### PR TITLE
[JENKINS-26824] Add tooltips for actions and checkboxes

### DIFF
--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -33,21 +33,21 @@ THE SOFTWARE.
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${descriptor.showPermission(p)}">
               <td width="*">
-                <f:checkbox name="[${p.id}]" checked="${instance.hasExplicitPermission(attrs.sid,p)}"/>
+                <f:checkbox name="[${p.id}]" tooltip="${p.group.title}/${p.name} for ${attrs.sid}" checked="${instance.hasExplicitPermission(attrs.sid,p)}"/>
               </td>
             </j:if>
           </j:forEach>
         </j:forEach>
         <td class="stop" style="text-align:left;">
           <a href="#" class="selectall">
-            <img alt="${%Select all}" src="${rootURL}/plugin/matrix-auth/images/16x16/select-all.png" height="16" width="16"/>
+            <img alt="${%Select all}" title="${%selectall(attrs.sid)}" src="${rootURL}/plugin/matrix-auth/images/16x16/select-all.png" height="16" width="16"/>
           </a>
           <a href="#" class="unselectall">
-            <img alt="${%Unselect all}" src="${rootURL}/plugin/matrix-auth/images/16x16/unselect-all.png" height="16" width="16"/>
+            <img alt="${%Unselect all}" title="${%unselectall(attrs.sid)}" src="${rootURL}/plugin/matrix-auth/images/16x16/unselect-all.png" height="16" width="16"/>
           </a>
           <j:if test="${attrs.sid!='anonymous'}">
             <a href="#" class="remove">
-              <img alt="${%Remove user/group}" src="${imagesURL}/16x16/stop.png" height="16" width="16"/>
+              <img alt="${%Remove user/group}" title="${%remove(attrs.sid)}" src="${imagesURL}/16x16/stop.png" height="16" width="16"/>
             </a>
           </j:if>
         </td>

--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.properties
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.properties
@@ -1,0 +1,3 @@
+selectall=Grant all permissions to {0}
+unselectall=Remove all permissions from {0}
+remove=Remove entries for {0}


### PR DESCRIPTION
Permissions:

![screen shot](https://user-images.githubusercontent.com/1831569/30504875-70a72dd4-9a71-11e7-9a1c-3e95c573dc6e.png)

Actions:

![screen shot](https://user-images.githubusercontent.com/1831569/30504878-731e12a8-9a71-11e7-8b87-1e461d73c29a.png)

Both use the user ID rather than the validated label, but that seems like a *lot* of work for relatively little benefit.