### PR TITLE
[JENKINS-34616] Add symbols, getter, and constructor for pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,13 @@
             <version>2.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- requireUpperBoundDeps -->
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,19 @@
             <version>2.1.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.30</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-multibranch</artifactId>
+            <version>2.10</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -34,9 +34,11 @@ import hudson.model.listeners.ItemListener;
 import hudson.util.FormValidation;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -46,6 +48,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.PrincipalSid;
 import org.acegisecurity.acls.sid.Sid;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.matrixauth.AbstractMatrixPropertyConverter;
 import org.jenkinsci.plugins.matrixauth.AuthorizationMatrixPropertyDescriptor;
 import org.jenkinsci.plugins.matrixauth.AuthorizationProperty;
@@ -54,6 +57,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -94,6 +99,26 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
             this.grantedPermissions.put(e.getKey(),new HashSet<>(e.getValue()));
     }
 
+    @DataBoundConstructor
+    public AuthorizationMatrixProperty(List<String> permissions) {
+        for (String str : permissions) {
+            if (str != null) {
+                this.add(str);
+            }
+        }
+    }
+
+    public List<String> getPermissions() {
+        List<String> permissions = new ArrayList<>();
+        for (Map.Entry<Permission, Set<String>> entry : this.grantedPermissions.entrySet()) {
+            for (String sid : entry.getValue()) {
+                String permission = entry.getKey().getId();
+                permissions.add(permission + ":" + sid);
+            }
+        }
+        return permissions;
+    }
+
 	public Set<String> getGroups() {
 		return sids;
 	}
@@ -122,6 +147,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 	}
 
     @Extension
+    @Symbol("authorizationMatrix")
     public static class DescriptorImpl extends JobPropertyDescriptor implements AuthorizationMatrixPropertyDescriptor<AuthorizationMatrixProperty> {
 
         @Override
@@ -165,6 +191,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 		return acl;
 	}
 
+	@DataBoundSetter
 	public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
 		this.inheritanceStrategy = inheritanceStrategy;
 	}

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -106,7 +106,6 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
 
     @DataBoundConstructor
     public AuthorizationMatrixProperty(List<String> permissions) {
-        // FIXME this needs to ensure all the permissions are actually applicable to this object, and log a warning if not (or fail outright)
         for (String str : permissions) {
             if (str != null) {
                 this.add(str);

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
@@ -61,6 +61,8 @@ public interface AuthorizationContainer {
 
     void add(Permission permission, String sid);
     Map<Permission, Set<String>> getGrantedPermissions();
+
+    @SuppressWarnings("rawtypes")
     Descriptor getDescriptor();
 
     /**
@@ -74,7 +76,7 @@ public interface AuthorizationContainer {
         if (p==null)
             throw new IllegalArgumentException("Failed to parse '"+shortForm+"' --- no such permission");
         String sid = shortForm.substring(idx + 1);
-        if (!p.isContainedBy(((AuthorizationContainerDescriptor) getDescriptor()).getPermissionScope())) {
+        if (!p.isContainedBy(((AuthorizationContainerDescriptor<?>) getDescriptor()).getPermissionScope())) {
             Logger.getLogger(AuthorizationContainer.class.getName()).log(Level.WARNING,
                     "Tried to add inapplicable permission " + p + " for " + sid + " in " + this + ", skipping");
             return;

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy.java
@@ -28,6 +28,7 @@ import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
@@ -47,6 +48,7 @@ public class InheritGlobalStrategy extends InheritanceStrategy {
         return ProjectMatrixAuthorizationStrategy.inheritingACL(Jenkins.getInstance().getAuthorizationStrategy().getRootACL(), acl);
     }
 
+    @Symbol("inheritingGlobal")
     @Extension
     public static class DescriptorImpl extends InheritanceStrategyDescriptor {
 

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy.java
@@ -30,6 +30,7 @@ import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
@@ -63,6 +64,7 @@ public class InheritParentStrategy extends InheritanceStrategy {
         }
     }
 
+    @Symbol("inheriting")
     @Extension(ordinal = 100)
     public static class DescriptorImpl extends InheritanceStrategyDescriptor {
 

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/InheritanceStrategyDescriptor.java
@@ -27,7 +27,6 @@ import hudson.DescriptorExtensionList;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy.java
@@ -29,6 +29,7 @@ import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
@@ -69,7 +70,8 @@ public class NonInheritingStrategy extends InheritanceStrategy {
             }
         };
     }
-    
+
+    @Symbol("nonInheriting")
     @Extension(ordinal = -100)
     public static class DescriptorImpl extends InheritanceStrategyDescriptor {
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixPropertyTest.java
@@ -35,21 +35,26 @@ import hudson.security.ACLContext;
 import hudson.security.HudsonPrivateSecurityRealm;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
 
 import jenkins.model.Jenkins;
 import org.acegisecurity.AccessDeniedException;
 import static org.junit.Assert.*;
 
+import org.jenkinsci.plugins.matrixauth.AuthorizationContainer;
 import org.junit.Assert;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 
 public class AuthorizationMatrixPropertyTest {
 
     @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Rule public LoggerRule l = new LoggerRule();
 
     @Test
     public void ensureCreatorHasPermissions() throws Exception {
@@ -149,5 +154,16 @@ public class AuthorizationMatrixPropertyTest {
 
         wc = r.createWebClient().login("alice");
         wc.getPage(foo);    // this should succeed
+    }
+
+    @Test
+    public void inapplicablePermissionIsSkipped() throws Exception {
+        AuthorizationMatrixProperty property = new AuthorizationMatrixProperty();
+        l.record(AuthorizationContainer.class, Level.WARNING).capture(1);
+        property.add("hudson.model.Hudson.Administer:alice");
+        assertTrue(property.getGrantedPermissions().isEmpty());
+        assertTrue(l.getMessages().get(0).contains("Tried to add inapplicable permission"));
+        assertTrue(l.getMessages().get(0).contains("Administer"));
+        assertTrue(l.getMessages().get(0).contains("alice"));
     }
 }

--- a/src/test/java/hudson/security/AuthorizationMatrixPropertyTest.java
+++ b/src/test/java/hudson/security/AuthorizationMatrixPropertyTest.java
@@ -1,0 +1,86 @@
+package hudson.security;
+
+import hudson.model.Item;
+import hudson.scm.SCM;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.multibranch.JobPropertyStep;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+public class AuthorizationMatrixPropertyTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testSnippetizer() throws Exception {
+        AuthorizationMatrixProperty property = new AuthorizationMatrixProperty(Collections.emptyMap());
+        property.add(Item.CONFIGURE, "alice");
+        property.add(Item.READ, "bob");
+        property.add(Item.READ, "alice");
+        property.add(SCM.TAG, "bob"); // use this to test for JENKINS-17200 robustness
+        property.setInheritanceStrategy(new NonInheritingStrategy());
+        SnippetizerTester tester = new SnippetizerTester(j);
+        tester.assertRoundTrip(new JobPropertyStep(Collections.singletonList(property)),
+                "properties([authorizationMatrix(inheritanceStrategy: nonInheriting(), " +
+                "permissions: ['hudson.model.Item.Configure:alice', 'hudson.model.Item.Read:alice', 'hudson.model.Item.Read:bob', 'hudson.scm.SCM.Tag:bob'])])");
+    }
+
+    @Test
+    public void testPipelineReconfiguration() throws Exception {
+
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(true, false, null);
+        realm.createAccount("alice", "alice");
+        realm.createAccount("bob", "bob");
+        realm.createAccount("carol", "carol");
+        j.jenkins.setSecurityRealm(realm);
+
+        ProjectMatrixAuthorizationStrategy strategy = new ProjectMatrixAuthorizationStrategy();
+        strategy.add(Jenkins.ADMINISTER, "alice");
+        strategy.add(Jenkins.READ, "bob");
+        strategy.add(Jenkins.READ, "carol");
+        strategy.add(Item.READ, "carol");
+
+        j.jenkins.setAuthorizationStrategy(strategy);
+
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+
+        // bob cannot see the project due to lack of Item.Read
+        j.createWebClient().login("bob").assertFails(project.getUrl(), 404);
+
+        // but bob can discover the project and get a 403
+        strategy.add(Item.DISCOVER, "bob");
+        j.createWebClient().login("bob").assertFails(project.getUrl(), 403);
+
+        // alice OTOH is admin and can see it
+        j.createWebClient().login("alice").goTo(project.getUrl()); // succeeds
+
+        // carol can also see the project, she has global Item.Read
+        j.createWebClient().login("carol").goTo(project.getUrl());
+
+        project.setDefinition(new CpsFlowDefinition("properties([authorizationMatrix(inheritanceStrategy: nonInheriting(), " +
+                "permissions: ['hudson.model.Item.Read:bob', 'hudson.model.Item.Configure:bob', 'hudson.scm.SCM.Tag:bob'])])", true));
+        j.buildAndAssertSuccess(project);
+
+        // let's look ast the property
+        AuthorizationMatrixProperty property = project.getProperty(AuthorizationMatrixProperty.class);
+        Assert.assertTrue(property.getInheritanceStrategy() instanceof NonInheritingStrategy);
+        Assert.assertEquals(3, property.getGrantedPermissions().size());
+        Assert.assertEquals("bob", property.getGroups().toArray()[0]);
+
+        // now bob has access, including configure
+        j.createWebClient().login("bob").goTo(project.getUrl());
+        j.createWebClient().login("bob").goTo(project.getUrl() + "configure");
+
+        // and carol no longer has access due to non-inheriting strategy
+        j.createWebClient().login("carol").assertFails(project.getUrl(), 404);
+    }
+}

--- a/src/test/java/hudson/security/AuthorizationMatrixPropertyTest.java
+++ b/src/test/java/hudson/security/AuthorizationMatrixPropertyTest.java
@@ -46,6 +46,7 @@ public class AuthorizationMatrixPropertyTest {
     @Issue("JENKINS-46944")
     public void testSnippetizerInapplicablePermission() throws Exception {
         AuthorizationMatrixProperty property = new AuthorizationMatrixProperty(Collections.emptyMap());
+        l.record(AuthorizationContainer.class, Level.WARNING).capture(1);
         property.add("hudson.model.Item.Configure:alice");
         property.add("hudson.model.Item.Read:bob");
         property.add("hudson.model.Item.Read:alice");
@@ -54,14 +55,13 @@ public class AuthorizationMatrixPropertyTest {
 
         property.setInheritanceStrategy(new NonInheritingStrategy());
 
-        l.record(AuthorizationContainer.class, Level.WARNING).capture(1);
         SnippetizerTester tester = new SnippetizerTester(j);
         tester.assertRoundTrip(new JobPropertyStep(Collections.singletonList(property)),
                 "properties([authorizationMatrix(inheritanceStrategy: nonInheriting(), " +
                         "permissions: ['hudson.model.Item.Configure:alice', 'hudson.model.Item.Read:alice', 'hudson.model.Item.Read:bob', 'hudson.scm.SCM.Tag:bob'])])");
 
         Assert.assertTrue(l.getMessages().get(0).contains("Tried to add inapplicable permission"));
-        Assert.assertTrue(l.getMessages().get(0).contains("Hudson.Read"));
+        Assert.assertTrue(l.getMessages().get(0).contains("Hudson,Read"));
         Assert.assertTrue(l.getMessages().get(0).contains("carol"));
     }
 


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/matrix-auth-plugin/pull/14

[JENKINS-34616](https://issues.jenkins-ci.org/browse/JENKINS-34616)

- ~~I don't like the fully qualified permission IDs – ideally, they would be shortened to "Class.Field" if unambiguous.~~ (JENKINS-17200)
- ~~Needs usage docs~~ Optional, sort of, snippet gen works after all.
- [x] Needs autotests, manual testing etc.

----

Snippet generator:

> ![screen shot](https://user-images.githubusercontent.com/1831569/30508169-c06d05ea-9a90-11e7-8d6b-518726adaddb.png)

Result (formatted for readability):

```groovy
properties([
    authorizationMatrix(
        inheritanceStrategy: nonInheriting(), 
        permissions: [
            'hudson.model.Item.Read:authenticated', 
            'hudson.model.Run.Delete:danielbeck', 
            'hudson.model.Item.Build:danielbeck', 
            'hudson.model.Item.Configure:danielbeck']
            ),
    pipelineTriggers([])])
```

@jenkinsci/code-reviewers assemble!