### PR TITLE
Further cleanup addressing more copied code

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -98,7 +98,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
 
     @Restricted(NoExternalUse.class)
     public Set<String> getGroups() {
-        return sids;
+        return new HashSet<>(sids);
     }
 
     /**

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -34,18 +34,18 @@ import hudson.model.User;
 import hudson.model.listeners.ItemListener;
 import hudson.security.AuthorizationStrategy;
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.matrixauth.AuthorizationMatrixPropertyDescriptor;
-import hudson.security.GlobalMatrixAuthorizationStrategy;
+import org.jenkinsci.plugins.matrixauth.AuthorizationPropertyDescriptor;
 import hudson.security.Permission;
 import hudson.security.PermissionScope;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import hudson.security.SidACL;
-import org.jenkinsci.plugins.matrixauth.AbstractMatrixPropertyConverter;
+import org.jenkinsci.plugins.matrixauth.AbstractAuthorizationPropertyConverter;
 import org.jenkinsci.plugins.matrixauth.AuthorizationProperty;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.Sid;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
@@ -96,6 +96,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
             this.grantedPermissions.put(e.getKey(),new HashSet<>(e.getValue()));
     }
 
+    @Restricted(NoExternalUse.class)
     public Set<String> getGroups() {
         return sids;
     }
@@ -124,10 +125,10 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
     }
 
     @Extension(optional = true)
-    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor implements AuthorizationMatrixPropertyDescriptor<AuthorizationMatrixProperty> {
+    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor implements AuthorizationPropertyDescriptor<AuthorizationMatrixProperty> {
 
         @Override
-        public AuthorizationMatrixProperty createProperty() {
+        public AuthorizationMatrixProperty create() {
             return new AuthorizationMatrixProperty();
         }
 
@@ -147,7 +148,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
         }
 
         public FormValidation doCheckName(@AncestorInPath AbstractFolder<?> folder, @QueryParameter String value) {
-            return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value, folder, Item.CONFIGURE);
+            return doCheckName_(value, folder, Item.CONFIGURE);
         }
     }
 
@@ -177,13 +178,14 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
      * Persist {@link ProjectMatrixAuthorizationStrategy} as a list of IDs that
      * represent {@link ProjectMatrixAuthorizationStrategy#grantedPermissions}.
      */
-    public static final class ConverterImpl extends AbstractMatrixPropertyConverter {
+    @Restricted(DoNotUse.class)
+    public static final class ConverterImpl extends AbstractAuthorizationPropertyConverter<AuthorizationMatrixProperty> {
         public boolean canConvert(Class type) {
             return type == AuthorizationMatrixProperty.class;
         }
 
         @Override
-        public AuthorizationProperty createSubject() {
+        public AuthorizationMatrixProperty create() {
             return new AuthorizationMatrixProperty();
         }
     }

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -96,7 +96,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
     }
 
     public Set<String> getGroups() {
-        return sids;
+        return new HashSet<>(sids);
     }
 
     /**

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -46,10 +46,11 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.PrincipalSid;
 import org.acegisecurity.acls.sid.Sid;
-import org.jenkinsci.plugins.matrixauth.AbstractMatrixPropertyConverter;
-import org.jenkinsci.plugins.matrixauth.AuthorizationMatrixPropertyDescriptor;
+import org.jenkinsci.plugins.matrixauth.AbstractAuthorizationPropertyConverter;
+import org.jenkinsci.plugins.matrixauth.AuthorizationPropertyDescriptor;
 import org.jenkinsci.plugins.matrixauth.AuthorizationProperty;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
@@ -65,67 +66,66 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implements AuthorizationProperty {
 
-	private final transient SidACL acl = new AclImpl();
+    private final transient SidACL acl = new AclImpl();
 
-	/**
-	 * List up all permissions that are granted.
-	 * 
-	 * Strings are either the granted authority or the principal, which is not
-	 * distinguished.
-	 */
-	private final Map<Permission, Set<String>> grantedPermissions = new HashMap<>();
+    /**
+     * List up all permissions that are granted.
+     * <p>
+     * Strings are either the granted authority or the principal, which is not
+     * distinguished.
+     */
+    private final Map<Permission, Set<String>> grantedPermissions = new HashMap<>();
 
-	private final Set<String> sids = new HashSet<>();
+    private final Set<String> sids = new HashSet<>();
 
-	/**
-	 * @deprecated unused, use {@link #setInheritanceStrategy(InheritanceStrategy)} instead.
-	 */
-	@Deprecated
+    /**
+     * @deprecated unused, use {@link #setInheritanceStrategy(InheritanceStrategy)} instead.
+     */
+    @Deprecated
     private transient Boolean blocksInheritance;
 
-	private InheritanceStrategy inheritanceStrategy = new InheritParentStrategy();
+    private InheritanceStrategy inheritanceStrategy = new InheritParentStrategy();
 
     private AuthorizationMatrixProperty() {
     }
 
     public AuthorizationMatrixProperty(Map<Permission, Set<String>> grantedPermissions) {
         // do a deep copy to be safe
-        for (Entry<Permission,Set<String>> e : grantedPermissions.entrySet())
-            this.grantedPermissions.put(e.getKey(),new HashSet<>(e.getValue()));
+        for (Entry<Permission, Set<String>> e : grantedPermissions.entrySet())
+            this.grantedPermissions.put(e.getKey(), new HashSet<>(e.getValue()));
     }
 
-	public Set<String> getGroups() {
-		return sids;
-	}
+    public Set<String> getGroups() {
+        return sids;
+    }
 
     /**
      * Returns all the (Permission,sid) pairs that are granted, in the multi-map form.
      *
-     * @return
-     *      read-only. never null.
+     * @return read-only. never null.
      */
-    public Map<Permission,Set<String>> getGrantedPermissions() {
+    public Map<Permission, Set<String>> getGrantedPermissions() {
         return Collections.unmodifiableMap(grantedPermissions);
     }
 
     /**
-	 * Adds to {@link #grantedPermissions}. Use of this method should be limited
-	 * during construction, as this object itself is considered immutable once
-	 * populated.
-	 */
-	public void add(Permission p, String sid) {
-		Set<String> set = grantedPermissions.get(p);
-		if (set == null)
-			grantedPermissions.put(p, set = new HashSet<>());
-		set.add(sid);
-		sids.add(sid);
-	}
+     * Adds to {@link #grantedPermissions}. Use of this method should be limited
+     * during construction, as this object itself is considered immutable once
+     * populated.
+     */
+    public void add(Permission p, String sid) {
+        Set<String> set = grantedPermissions.get(p);
+        if (set == null)
+            grantedPermissions.put(p, set = new HashSet<>());
+        set.add(sid);
+        sids.add(sid);
+    }
 
     @Extension
-    public static class DescriptorImpl extends JobPropertyDescriptor implements AuthorizationMatrixPropertyDescriptor<AuthorizationMatrixProperty> {
+    public static class DescriptorImpl extends JobPropertyDescriptor implements AuthorizationPropertyDescriptor<AuthorizationMatrixProperty> {
 
         @Override
-        public AuthorizationMatrixProperty createProperty() {
+        public AuthorizationMatrixProperty create() {
             return new AuthorizationMatrixProperty();
         }
 
@@ -133,97 +133,98 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
         public PermissionScope getPermissionScope() {
             return PermissionScope.ITEM;
         }
-        
-		@Override
-		public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return createNewInstance(req, formData, true);
-		}
 
-		@Override
-		public boolean isApplicable(Class<? extends Job> jobType) {
+        @Override
+        public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return createNewInstance(req, formData, true);
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends Job> jobType) {
             return isApplicable();
-		}
+        }
 
         public FormValidation doCheckName(@AncestorInPath Job project, @QueryParameter String value) {
-            return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value, project, Item.CONFIGURE);
+            return doCheckName_(value, project, Item.CONFIGURE);
         }
     }
 
-	private final class AclImpl extends SidACL {
-                @CheckForNull
-                @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", 
-                        justification = "As designed, implements a third state for the ternary logic")
-		protected Boolean hasPermission(Sid sid, Permission p) {
-			if (AuthorizationMatrixProperty.this.hasPermission(toString(sid),p,sid instanceof PrincipalSid)) {
-				return true;
+    private final class AclImpl extends SidACL {
+        @CheckForNull
+        @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL",
+                justification = "As designed, implements a third state for the ternary logic")
+        protected Boolean hasPermission(Sid sid, Permission p) {
+            if (AuthorizationMatrixProperty.this.hasPermission(toString(sid), p, sid instanceof PrincipalSid)) {
+                return true;
+            }
+            return null;
+        }
+    }
+
+    public SidACL getACL() {
+        return acl;
+    }
+
+    public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
+        this.inheritanceStrategy = inheritanceStrategy;
+    }
+
+    public InheritanceStrategy getInheritanceStrategy() {
+        return inheritanceStrategy;
+    }
+
+    /**
+     * Persist {@link ProjectMatrixAuthorizationStrategy} as a list of IDs that
+     * represent {@link ProjectMatrixAuthorizationStrategy#grantedPermissions}.
+     */
+    @Restricted(DoNotUse.class)
+    public static final class ConverterImpl extends AbstractAuthorizationPropertyConverter<AuthorizationMatrixProperty> {
+        public boolean canConvert(Class type) {
+            return type == AuthorizationMatrixProperty.class;
+        }
+
+        public AuthorizationMatrixProperty create() {
+            return new AuthorizationMatrixProperty();
+        }
+    }
+
+    /**
+     * Ensure that the user creating a job has Read and Configure permissions
+     */
+    @Extension
+    @Restricted(NoExternalUse.class)
+    public static class ItemListenerImpl extends ItemListener {
+        @Override
+        public void onCreated(Item item) {
+            AuthorizationStrategy authorizationStrategy = Jenkins.getInstance().getAuthorizationStrategy();
+            if (authorizationStrategy instanceof ProjectMatrixAuthorizationStrategy) {
+                ProjectMatrixAuthorizationStrategy strategy = (ProjectMatrixAuthorizationStrategy) authorizationStrategy;
+
+                if (item instanceof Job) {
+                    Job<?, ?> job = (Job<?, ?>) item;
+                    AuthorizationMatrixProperty prop = job.getProperty(AuthorizationMatrixProperty.class);
+                    if (prop == null) {
+                        prop = new AuthorizationMatrixProperty();
+                    }
+
+                    User current = User.current();
+                    String sid = current == null ? "anonymous" : current.getId();
+
+                    if (!strategy.getACL(job).hasPermission(Jenkins.getAuthentication(), Item.READ)) {
+                        prop.add(Item.READ, sid);
+                    }
+                    if (!strategy.getACL(job).hasPermission(Jenkins.getAuthentication(), Item.CONFIGURE)) {
+                        prop.add(Item.CONFIGURE, sid);
+                    }
+                    if (prop.getGrantedPermissions().size() > 0) {
+                        try {
+                            job.addProperty(prop);
+                        } catch (IOException ex) {
+                            // TODO LOGGER
                         }
-			return null;
-		}
-	}
-
-	public SidACL getACL() {
-		return acl;
-	}
-
-	public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
-		this.inheritanceStrategy = inheritanceStrategy;
-	}
-
-	public InheritanceStrategy getInheritanceStrategy() {
-		return inheritanceStrategy;
-	}
-
-	/**
-	 * Persist {@link ProjectMatrixAuthorizationStrategy} as a list of IDs that
-	 * represent {@link ProjectMatrixAuthorizationStrategy#grantedPermissions}.
-	 */
-	public static final class ConverterImpl extends AbstractMatrixPropertyConverter {
-		public boolean canConvert(Class type) {
-			return type == AuthorizationMatrixProperty.class;
-		}
-
-		public AuthorizationProperty createSubject() {
-		    return new AuthorizationMatrixProperty();
+                    }
+                }
+            }
         }
     }
-
-	/**
-	 * Ensure that the user creating a job has Read and Configure permissions
-	 */
-	@Extension
-	@Restricted(NoExternalUse.class)
-	public static class ItemListenerImpl extends ItemListener {
-		@Override
-		public void onCreated(Item item) {
-			AuthorizationStrategy authorizationStrategy = Jenkins.getInstance().getAuthorizationStrategy();
-			if (authorizationStrategy instanceof ProjectMatrixAuthorizationStrategy) {
-				ProjectMatrixAuthorizationStrategy strategy = (ProjectMatrixAuthorizationStrategy) authorizationStrategy;
-
-				if (item instanceof Job) {
-					Job<?, ?> job = (Job<?, ?>) item;
-					AuthorizationMatrixProperty prop = job.getProperty(AuthorizationMatrixProperty.class);
-					if (prop == null) {
-						prop = new AuthorizationMatrixProperty();
-					}
-
-					User current = User.current();
-					String sid = current == null ? "anonymous" : current.getId();
-
-					if (!strategy.getACL(job).hasPermission(Jenkins.getAuthentication(), Item.READ)) {
-						prop.add(Item.READ, sid);
-					}
-					if (!strategy.getACL(job).hasPermission(Jenkins.getAuthentication(), Item.CONFIGURE)) {
-						prop.add(Item.CONFIGURE, sid);
-					}
-					if (prop.getGrantedPermissions().size() > 0) {
-						try {
-							job.addProperty(prop);
-						} catch (IOException ex) {
-							// TODO LOGGER
-						}
-					}
-				}
-			}
-		}
-	}
 }

--- a/src/main/java/hudson/security/DangerousMatrixPermissionsAdministrativeMonitor.java
+++ b/src/main/java/hudson/security/DangerousMatrixPermissionsAdministrativeMonitor.java
@@ -37,6 +37,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Administrative monitor that shows up when 'dangerous' permissions are granted to non-admin users.
+ * Those are permissions that could be used to grant themselves administer permissions.
+ *
+ * See also https://jenkins.io/security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
+ */
 @Extension
 @Restricted(DoNotUse.class)
 public class DangerousMatrixPermissionsAdministrativeMonitor extends AdministrativeMonitor {

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -151,8 +151,9 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy imp
     
     public static class DescriptorImpl extends Descriptor<AuthorizationStrategy> implements AuthorizationContainerDescriptor<GlobalMatrixAuthorizationStrategy> {
 
-        DescriptorImpl() {
+        public DescriptorImpl() {
             // make this constructor available for instantiation for ProjectMatrixAuthorizationStrategy
+            // public for role-strategy plugin
         }
 
         @Override

--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -36,6 +36,7 @@ import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.matrixauth.AuthorizationMatrixNodeProperty;
 import org.jenkinsci.plugins.matrixauth.Messages;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
@@ -145,10 +146,11 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
         }
     };
 
+    @Restricted(DoNotUse.class)
     public static class ConverterImpl extends GlobalMatrixAuthorizationStrategy.ConverterImpl {
 
         @Override
-        protected GlobalMatrixAuthorizationStrategy create() {
+        public GlobalMatrixAuthorizationStrategy create() {
             return new ProjectMatrixAuthorizationStrategy();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractAuthorizationContainerConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AbstractAuthorizationContainerConverter.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2017 Sun Microsystems, Inc., Kohsuke Kawaguchi, Yahoo! Inc., Peter Hayes, Tom Huybrechts, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.matrixauth;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.util.RobustReflectionConverter;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Restricted(NoExternalUse.class)
+public abstract class AbstractAuthorizationContainerConverter<T extends AuthorizationContainer> implements Converter {
+
+    abstract public boolean canConvert(Class type);
+
+    abstract public T create();
+
+    @SuppressWarnings("unchecked")
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        final GlobalMatrixAuthorizationStrategy.IdStrategyComparator comparator = new GlobalMatrixAuthorizationStrategy.IdStrategyComparator();
+
+        if (!canConvert(source.getClass())) {
+            throw new IllegalArgumentException("cannot marshal object of type " + source.getClass());
+        }
+        T container = (T) source;
+
+        // Output in alphabetical order for readability.
+        SortedMap<Permission, Set<String>> sortedPermissions = new TreeMap<>(Permission.ID_COMPARATOR);
+        sortedPermissions.putAll(container.getGrantedPermissions());
+
+        for (Map.Entry<Permission, Set<String>> e : sortedPermissions.entrySet()) {
+            String p = e.getKey().getId();
+            Set<String> sids = new TreeSet<>(comparator);
+            sids.addAll(e.getValue());
+
+            for (String sid : sids) {
+                writer.startNode("permission");
+                writer.setValue(p + ':' + sid);
+                writer.endNode();
+            }
+        }
+    }
+
+    protected void unmarshalContainer(T container, HierarchicalStreamReader reader, final UnmarshallingContext context) {
+        while (reader.hasMoreChildren()) {
+            reader.moveDown();
+            try {
+                container.add(reader.getValue());
+            } catch (IllegalArgumentException ex) {
+                // TODO Logger field
+                Logger.getLogger(GlobalMatrixAuthorizationStrategy.class.getName())
+                        .log(Level.WARNING,"Skipping a non-existent permission",ex);
+                RobustReflectionConverter.addErrorInContext(context, ex);
+            }
+            reader.moveUp();
+        }
+    }
+
+    public Object unmarshal(HierarchicalStreamReader reader, final UnmarshallingContext context) {
+        T container = create();
+        unmarshalContainer(container, reader, context);
+
+        return container;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
@@ -1,0 +1,194 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2017 Sun Microsystems, Inc., Kohsuke Kawaguchi, Yahoo! Inc., Peter Hayes, Tom Huybrechts, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.matrixauth;
+
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.security.SecurityRealm;
+import jenkins.model.IdStrategy;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+public interface AuthorizationContainer {
+
+    @Restricted(NoExternalUse.class)
+    class IdStrategyComparator implements Comparator<String> {
+        private final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+        private final IdStrategy groupIdStrategy = securityRealm.getGroupIdStrategy();
+        private final IdStrategy userIdStrategy = securityRealm.getUserIdStrategy();
+
+        public int compare(String o1, String o2) {
+            int r = userIdStrategy.compare(o1, o2);
+            if (r == 0) {
+                r = groupIdStrategy.compare(o1, o2);
+            }
+            return r;
+        }
+    }
+
+    void add(Permission permission, String sid);
+    Map<Permission, Set<String>> getGrantedPermissions();
+
+    /**
+     * Works like {@link #add(Permission, String)} but takes both parameters
+     * from a single string of the form <tt>PERMISSIONID:sid</tt>
+     */
+    @Restricted(NoExternalUse.class)
+    default void add(String shortForm) {
+        int idx = shortForm.indexOf(':');
+        Permission p = Permission.fromId(shortForm.substring(0, idx));
+        if (p==null)
+            throw new IllegalArgumentException("Failed to parse '"+shortForm+"' --- no such permission");
+        add(p, shortForm.substring(idx + 1));
+    }
+
+    /**
+     * Returns all SIDs configured in this matrix, minus "anonymous"
+     *
+     * @return Always non-null.
+     */
+    default List<String> getAllSIDs() {
+        Set<String> r = new TreeSet<>(new GlobalMatrixAuthorizationStrategy.IdStrategyComparator());
+        for (Set<String> set : getGrantedPermissions().values())
+            r.addAll(set);
+        r.remove("anonymous");
+
+        String[] data = r.toArray(new String[r.size()]);
+        Arrays.sort(data);
+        return Arrays.asList(data);
+    }
+
+    @Restricted(NoExternalUse.class)
+    default boolean isAnyRelevantDangerousPermissionExplicitlyGranted() {
+        for (String sid : getAllSIDs()) {
+            if (isAnyRelevantDangerousPermissionExplicitlyGranted(sid)) {
+                return true;
+            }
+        }
+        return isAnyRelevantDangerousPermissionExplicitlyGranted("anonymous");
+    }
+
+    @Restricted(NoExternalUse.class)
+    default boolean isAnyRelevantDangerousPermissionExplicitlyGranted(String sid) {
+        for (Permission p : GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS) {
+            if (!hasPermission(sid, Jenkins.ADMINISTER) && hasExplicitPermission(sid, p)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the given SID has the given permission.
+     */
+    default boolean hasPermission(String sid, Permission p) {
+        if (!GlobalMatrixAuthorizationStrategy.ENABLE_DANGEROUS_PERMISSIONS
+                && GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS.contains(p)) {
+            return hasPermission(sid, Jenkins.ADMINISTER);
+        }
+        final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+        final IdStrategy groupIdStrategy = securityRealm.getGroupIdStrategy();
+        final IdStrategy userIdStrategy = securityRealm.getUserIdStrategy();
+        for (; p != null; p = p.impliedBy) {
+            if (!p.getEnabled()) {
+                continue;
+            }
+            Set<String> set = getGrantedPermissions().get(p);
+            if (set == null) {
+                continue;
+            }
+            if (set.contains(sid)) {
+                return true;
+            }
+            for (String s: set) {
+                if (userIdStrategy.equals(s, sid) || groupIdStrategy.equals(s, sid)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the given SID has the given permission.
+     */
+    default boolean hasPermission(String sid, Permission p, boolean principal) {
+        if (!GlobalMatrixAuthorizationStrategy.ENABLE_DANGEROUS_PERMISSIONS
+                && GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS.contains(p)) {
+            return hasPermission(sid, Jenkins.ADMINISTER, principal);
+        }
+        final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+        final IdStrategy strategy = principal ? securityRealm.getUserIdStrategy() : securityRealm.getGroupIdStrategy();
+        for (; p != null; p = p.impliedBy) {
+            if (!p.getEnabled()) {
+                continue;
+            }
+            Set<String> set = getGrantedPermissions().get(p);
+            if (set == null) {
+                continue;
+            }
+            if (set.contains(sid)) {
+                return true;
+            }
+            for (String s : set) {
+                if (strategy.equals(s, sid)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the permission is explicitly given, instead of implied through {@link Permission#impliedBy}.
+     */
+    default boolean hasExplicitPermission(String sid, Permission p) {
+        if (sid == null) { // used for template row in UI
+            return false;
+        }
+        Set<String> set = getGrantedPermissions().get(p);
+        if (set != null && p.getEnabled()) {
+            if (set.contains(sid))
+                return true;
+            final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
+            final IdStrategy groupIdStrategy = securityRealm.getGroupIdStrategy();
+            final IdStrategy userIdStrategy = securityRealm.getUserIdStrategy();
+            for (String s: set) {
+                if (userIdStrategy.equals(s, sid) || groupIdStrategy.equals(s, sid)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+@Restricted(NoExternalUse.class)
 public interface AuthorizationContainer {
 
     @Restricted(NoExternalUse.class)

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
@@ -74,6 +74,9 @@ public interface AuthorizationContainerDescriptor<T extends AuthorizationContain
             if (group == PermissionGroup.get(Permission.class)) {
                 continue;
             }
+            if (!group.hasPermissionContainedBy(getPermissionScope())) {
+                continue;
+            }
             for (Permission p : group.getPermissions()) {
                 if (p.getEnabled()) {
                     groups.add(group);

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
@@ -1,0 +1,171 @@
+package org.jenkinsci.plugins.matrixauth;
+
+import hudson.Functions;
+import hudson.Util;
+import hudson.model.User;
+import hudson.security.AccessControlled;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import hudson.security.PermissionScope;
+import hudson.security.SecurityRealm;
+import hudson.security.UserMayOrMayNotExistException;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import org.acegisecurity.AuthenticationException;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.springframework.dao.DataAccessException;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jenkinsci.plugins.matrixauth.ValidationUtil.formatNonExistentUserGroupValidationResponse;
+import static org.jenkinsci.plugins.matrixauth.ValidationUtil.formatUserGroupValidationResponse;
+
+/**
+ * Interface methods common to descriptors of authorization strategy and the various properties.
+ *
+ * Mostly some methods used from the similar configuration UI for these (reuse there).
+ *
+ */
+public interface AuthorizationContainerDescriptor<T extends AuthorizationContainer> {
+
+    PermissionScope getPermissionScope();
+
+    @Restricted(DoNotUse.class) // Called from Jelly view to show fancy tool tips
+    default String getDescription(Permission p) {
+        String description = p.description == null ? "" : p.description.toString();
+        Permission impliedBy = p.impliedBy;
+        while (impliedBy != null && impliedBy.group == PermissionGroup.get(Permission.class)) {
+            if (impliedBy.impliedBy == null) {
+                break;
+            }
+            impliedBy = impliedBy.impliedBy;
+        }
+        if (impliedBy == null) {
+            // this permission is not implied by anything else, this is notable
+            if (description.length() > 0) {
+                description += "<br/><br/>";
+            }
+            description += Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy();
+        } else if (impliedBy != Jenkins.ADMINISTER) {
+            // this is implied by a permission other than Administer
+            if (description.length() > 0) {
+                description += "<br/><br/>";
+            }
+            description += Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(impliedBy.group.title, impliedBy.name);
+        }
+
+        return description;
+    }
+
+    @Restricted(DoNotUse.class) // Called from Jelly view
+    default List<PermissionGroup> getAllGroups() {
+        // TODO parent impl
+        List<PermissionGroup> groups = new ArrayList<>();
+        for (PermissionGroup group : PermissionGroup.getAll()) {
+            if (group == PermissionGroup.get(Permission.class)) {
+                continue;
+            }
+            for (Permission p : group.getPermissions()) {
+                if (p.getEnabled()) {
+                    groups.add(group);
+                    break;
+                }
+            }
+        }
+        return groups;
+    }
+
+    @Restricted(DoNotUse.class) // Called from Jelly view
+    default boolean showPermission(Permission p) {
+        if (!p.getEnabled()) {
+            // Permission is disabled, so don't show it
+            return false;
+        }
+
+        // ensure the permission is defined in the correct permission scope
+        if (!p.isContainedBy(getPermissionScope())) {
+            return false;
+        }
+
+        if (GlobalMatrixAuthorizationStrategy.ENABLE_DANGEROUS_PERMISSIONS || !GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS.contains(p)) {
+            // we allow assignment of dangerous permissions, or it's a safe permission, so show it
+            return true;
+        }
+
+        // if we grant any dangerous permission, show them all
+        AuthorizationStrategy strategy = Jenkins.getInstance().getAuthorizationStrategy();
+        if (strategy instanceof GlobalMatrixAuthorizationStrategy) {
+            GlobalMatrixAuthorizationStrategy globalMatrixAuthorizationStrategy = (GlobalMatrixAuthorizationStrategy) strategy;
+            return globalMatrixAuthorizationStrategy.isAnyRelevantDangerousPermissionExplicitlyGranted();
+        }
+
+        // don't show by default, i.e. when initially configuring the authorization strategy
+        return false;
+    }
+
+
+    // Not used directly by Stapler due to the trailing _ (this prevented method confusion around 1.415).
+    @Restricted(NoExternalUse.class)
+    default FormValidation doCheckName_(@Nonnull String value, @Nonnull AccessControlled subject, @Nonnull Permission permission) {
+
+        final String v = value.substring(1,value.length()-1);
+        String ev = Functions.escape(v);
+
+        if(!subject.hasPermission(permission))  return FormValidation.ok(ev); // can't check
+
+        SecurityRealm sr = Jenkins.getInstance().getSecurityRealm();
+
+        if(v.equals("authenticated"))
+            // system reserved group
+            return FormValidation.respond(FormValidation.Kind.OK, formatUserGroupValidationResponse("user.png", ev, "Group", false));
+
+        try {
+            try {
+                sr.loadUserByUsername(v);
+                User u = User.get(v);
+                if (ev.equals(u.getFullName())) {
+                    return FormValidation.respond(FormValidation.Kind.OK, formatUserGroupValidationResponse("person.png", ev, "User", false));
+                }
+                return FormValidation.respond(FormValidation.Kind.OK, formatUserGroupValidationResponse("person.png", Util.escape(StringUtils.abbreviate(u.getFullName(), 50)), "User " + ev, false));
+            } catch (UserMayOrMayNotExistException e) {
+                // undecidable, meaning the user may exist
+                return FormValidation.respond(FormValidation.Kind.OK, ev);
+            } catch (UsernameNotFoundException |DataAccessException e) {
+                // fall through next
+            } catch (AuthenticationException e) {
+                // other seemingly unexpected error.
+                return FormValidation.error(e,"Failed to test the validity of the user name "+v);
+            }
+
+            try {
+                sr.loadGroupByGroupname(v);
+                return FormValidation.respond(FormValidation.Kind.OK, formatUserGroupValidationResponse("user.png", ev, "Group", false));
+            } catch (UserMayOrMayNotExistException e) {
+                // undecidable, meaning the group may exist
+                return FormValidation.respond(FormValidation.Kind.OK, ev);
+            } catch (UsernameNotFoundException|DataAccessException e) {
+                // fall through next
+            } catch (AuthenticationException e) {
+                // other seemingly unexpected error.
+                return FormValidation.error(e,"Failed to test the validity of the group name "+v);
+            }
+
+            // couldn't find it. it doesn't exist
+            return FormValidation.respond(FormValidation.Kind.ERROR, formatNonExistentUserGroupValidationResponse(ev, "User or group not found")); // TODO i18n
+        } catch (Exception e) {
+            // if the check fails miserably, we still want the user to be able to see the name of the user,
+            // so use 'ev' as the message
+            return FormValidation.error(e,ev);
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
@@ -35,6 +35,7 @@ import static org.jenkinsci.plugins.matrixauth.ValidationUtil.formatUserGroupVal
  * Mostly some methods used from the similar configuration UI for these (reuse there).
  *
  */
+@Restricted(NoExternalUse.class)
 public interface AuthorizationContainerDescriptor<T extends AuthorizationContainer> {
 
     PermissionScope getPermissionScope();

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -86,7 +86,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
 
     @Restricted(NoExternalUse.class)
     public Set<String> getGroups() {
-        return sids;
+        return new HashSet<>(sids);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -29,7 +29,6 @@ import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.User;
 import hudson.security.AuthorizationStrategy;
-import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.PermissionScope;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
@@ -43,6 +42,7 @@ import net.sf.json.JSONObject;
 import org.acegisecurity.acls.sid.PrincipalSid;
 import org.acegisecurity.acls.sid.Sid;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritGlobalStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
@@ -84,6 +84,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
             this.grantedPermissions.put(e.getKey(),new HashSet<>(e.getValue()));
     }
 
+    @Restricted(NoExternalUse.class)
     public Set<String> getGroups() {
         return sids;
     }
@@ -111,6 +112,7 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
      * during construction, as this object itself is considered immutable once
      * populated.
      */
+    // TODO Restrict?
     public void add(Permission p, String sid) {
         Set<String> set = grantedPermissions.get(p);
         if (set == null)
@@ -139,24 +141,27 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
      * Persist {@link ProjectMatrixAuthorizationStrategy} as a list of IDs that
      * represent {@link ProjectMatrixAuthorizationStrategy#grantedPermissions}.
      */
-    public static final class ConverterImpl extends AbstractMatrixPropertyConverter {
+    @Restricted(NoExternalUse.class)
+    public static final class ConverterImpl extends AbstractAuthorizationPropertyConverter<AuthorizationMatrixNodeProperty> {
         public boolean canConvert(Class type) {
             return type == AuthorizationMatrixNodeProperty.class;
         }
 
-        public AuthorizationProperty createSubject() {
+        public AuthorizationMatrixNodeProperty create() {
             return new AuthorizationMatrixNodeProperty();
         }
     }
 
     @Extension
-    public static class DescriptorImpl extends NodePropertyDescriptor implements AuthorizationMatrixPropertyDescriptor<AuthorizationMatrixNodeProperty> {
+    public static class DescriptorImpl extends NodePropertyDescriptor implements AuthorizationPropertyDescriptor<AuthorizationMatrixNodeProperty> {
 
+        @Restricted(NoExternalUse.class)
         @Override
-        public AuthorizationMatrixNodeProperty createProperty() {
+        public AuthorizationMatrixNodeProperty create() {
             return new AuthorizationMatrixNodeProperty();
         }
 
+        @Restricted(NoExternalUse.class)
         @Override
         public PermissionScope getPermissionScope() {
             return PermissionScope.COMPUTER;
@@ -178,9 +183,10 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
             return Messages.AuthorizationMatrixNodeProperty_DisplayName();
         }
 
+        @Restricted(DoNotUse.class)
         public FormValidation doCheckName(@AncestorInPath Computer computer, @QueryParameter String value) {
             // Computer isn't a DescriptorByNameOwner before Jenkins 2.78, and then @AncestorInPath doesn't work
-            return GlobalMatrixAuthorizationStrategy.DESCRIPTOR.doCheckName_(value,
+            return doCheckName_(value,
                     computer == null ? Jenkins.getInstance() : computer,
                     computer == null ? Jenkins.ADMINISTER : Computer.CONFIGURE);
         }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -23,26 +23,11 @@
  */
 package org.jenkinsci.plugins.matrixauth;
 
-import hudson.security.GlobalMatrixAuthorizationStrategy;
-import hudson.security.Permission;
-import hudson.security.SecurityRealm;
-import jenkins.model.IdStrategy;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritGlobalStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
-public interface AuthorizationProperty {
-    void add(Permission permission, String sid);
-    Map<Permission, Set<String>> getGrantedPermissions();
+public interface AuthorizationProperty extends AuthorizationContainer {
 
     void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy);
     InheritanceStrategy getInheritanceStrategy();
@@ -57,9 +42,8 @@ public interface AuthorizationProperty {
      *
      * Note that for items nested inside folders, this will change behavior significantly.
      *
-     * @param blocksInheritance
      * @since 2.0
-     * @deprecated
+     * @deprecated Use {@link InheritanceStrategy} instead.
      */
     @Deprecated
     default void setBlocksInheritance(boolean blocksInheritance) {
@@ -77,115 +61,12 @@ public interface AuthorizationProperty {
      * Since the introduction of inheritance strategies, returns {@code true}
      * if and only if the selected inheritance strategy is {@link NonInheritingStrategy}.
      *
-     * @return
      * @since 2.0
-     * @deprecated
+     * @deprecated Use {@link #getInheritanceStrategy()} instead.
      */
     @Deprecated
     default boolean isBlocksInheritance() {
         return getInheritanceStrategy() instanceof NonInheritingStrategy;
     }
 
-    /**
-     * Checks if the given SID has the given permission.
-     */
-    default boolean hasPermission(String sid, Permission p) {
-        final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
-        final IdStrategy groupIdStrategy = securityRealm.getGroupIdStrategy();
-        final IdStrategy userIdStrategy = securityRealm.getUserIdStrategy();
-        for (; p != null; p = p.impliedBy) {
-            if (!p.getEnabled()) {
-                continue;
-            }
-            Set<String> set = getGrantedPermissions().get(p);
-            if (set != null && set.contains(sid))
-                return true;
-            if (set != null) {
-                for (String s: set) {
-                    if (userIdStrategy.equals(s, sid) || groupIdStrategy.equals(s, sid)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Checks if the given SID has the given permission.
-     */
-    default boolean hasPermission(String sid, Permission p, boolean principal) {
-        final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
-        final IdStrategy strategy = principal ? securityRealm.getUserIdStrategy() : securityRealm.getGroupIdStrategy();
-        for (; p != null; p = p.impliedBy) {
-            if (!p.getEnabled()) {
-                continue;
-            }
-            Set<String> set = getGrantedPermissions().get(p);
-            if (set == null) {
-                continue;
-            }
-            if (set.contains(sid)) {
-                return true;
-            }
-            for (String s : set) {
-                if (strategy.equals(s, sid)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Checks if the permission is explicitly given, instead of implied through {@link Permission#impliedBy}.
-     */
-    default boolean hasExplicitPermission(String sid, Permission p) {
-        if (sid == null) { // used for template row in UI
-            return false;
-        }
-        Set<String> set = getGrantedPermissions().get(p);
-        if (set != null && p.getEnabled()) {
-            if (set.contains(sid))
-                return true;
-            final SecurityRealm securityRealm = Jenkins.getInstance().getSecurityRealm();
-            final IdStrategy groupIdStrategy = securityRealm.getGroupIdStrategy();
-            final IdStrategy userIdStrategy = securityRealm.getUserIdStrategy();
-            for (String s: set) {
-                if (userIdStrategy.equals(s, sid) || groupIdStrategy.equals(s, sid)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Works like {@link #add(Permission, String)} but takes both parameters
-     * from a single string of the form <tt>PERMISSIONID:sid</tt>
-     */
-    @Restricted(NoExternalUse.class)
-    default void add(String shortForm) {
-        int idx = shortForm.indexOf(':');
-        Permission p = Permission.fromId(shortForm.substring(0, idx));
-        if (p==null)
-            throw new IllegalArgumentException("Failed to parse '"+shortForm+"' --- no such permission");
-        add(p, shortForm.substring(idx + 1));
-    }
-
-    /**
-     * Returns all SIDs configured in this matrix, minus "anonymous"
-     *
-     * @return Always non-null.
-     */
-    default List<String> getAllSIDs() {
-        Set<String> r = new TreeSet<>(new GlobalMatrixAuthorizationStrategy.IdStrategyComparator());
-        for (Set<String> set : getGrantedPermissions().values())
-            r.addAll(set);
-        r.remove("anonymous");
-
-        String[] data = r.toArray(new String[r.size()]);
-        Arrays.sort(data);
-        return Arrays.asList(data);
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationProperty.java
@@ -26,7 +26,10 @@ package org.jenkinsci.plugins.matrixauth;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritGlobalStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+@Restricted(NoExternalUse.class)
 public interface AuthorizationProperty extends AuthorizationContainer {
 
     void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy);

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationPropertyDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationPropertyDescriptor.java
@@ -23,69 +23,71 @@
  */
 package org.jenkinsci.plugins.matrixauth;
 
+import hudson.model.Descriptor;
 import hudson.security.Permission;
-import hudson.security.PermissionGroup;
-import hudson.security.PermissionScope;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-public interface AuthorizationMatrixPropertyDescriptor<T extends AuthorizationProperty> {
+/**
+ * Interface with default methods common to all authorization related property descriptors.
+ * 
+ */
+@Restricted(NoExternalUse.class)
+public interface AuthorizationPropertyDescriptor<T extends AuthorizationProperty> extends AuthorizationContainerDescriptor<T> {
 
-    T createProperty();
+    T create();
 
-    PermissionScope getPermissionScope();
-
-    default T createNewInstance(StaplerRequest req, JSONObject formData, boolean hasOptionalWrap) {
+    default T createNewInstance(StaplerRequest req, JSONObject formData, boolean hasOptionalWrap) throws Descriptor.FormException {
         if (hasOptionalWrap) {
             formData = formData.getJSONObject("useProjectSecurity");
             if (formData.isNullObject())
                 return null;
         }
 
-        T amnp = createProperty();
+        T property = create();
 
-        amnp.setInheritanceStrategy(req.bindJSON(InheritanceStrategy.class, formData.getJSONObject("inheritanceStrategy")));
+        Map<String,Object> data = formData.getJSONObject("data");
 
-        for (Map.Entry<String, Object> r : (Set<Map.Entry<String, Object>>) formData.getJSONObject("data").entrySet()) {
+
+        property.setInheritanceStrategy(req.bindJSON(InheritanceStrategy.class, formData.getJSONObject("inheritanceStrategy")));
+
+        for (Map.Entry<String, Object> r : data.entrySet()) {
             String sid = r.getKey();
-            if (r.getValue() instanceof JSONObject) {
-                for (Map.Entry<String, Boolean> e : (Set<Map.Entry<String, Boolean>>) ((JSONObject) r
-                        .getValue()).entrySet()) {
-                    if (e.getValue()) {
-                        Permission p = Permission.fromId(e.getKey());
-                        amnp.add(p, sid);
+
+            if (!(r.getValue() instanceof JSONObject)) {
+                throw new Descriptor.FormException("not an object: " + formData, "data");
+            }
+            Map<String,Object> value = (JSONObject) r.getValue();
+
+            for (Map.Entry<String, Object> e : value.entrySet()) {
+                if (!(e.getValue() instanceof Boolean)) {
+                    throw new Descriptor.FormException("not an boolean: " + formData, "data");
+                }
+                if ((Boolean) e.getValue()) {
+                    Permission p = Permission.fromId(e.getKey());
+                    if (p == null) {
+                        Logger.getLogger(AuthorizationPropertyDescriptor.class.getName())
+                                .log(Level.FINE, "Silently skip unknown permission \"{0}\" for sid:\"{1}\"", new Object[]{e.getKey(), sid});
+                    } else {
+                        property.add(p, sid);
                     }
                 }
             }
         }
-        return amnp;
+        return property;
     }
 
     default boolean isApplicable() {
         // only applicable when ProjectMatrixAuthorizationStrategy is in charge
         return Jenkins.getInstance().getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy;
-    }
-
-    default List<PermissionGroup> getAllGroups() {
-        List<PermissionGroup> groups = new ArrayList<>();
-        for (PermissionGroup g : PermissionGroup.getAll()) {
-            if (g.hasPermissionContainedBy(getPermissionScope())) {
-                groups.add(g);
-            }
-        }
-        return groups;
-    }
-
-    default boolean showPermission(Permission p) {
-        return p.getEnabled() && p.isContainedBy(getPermissionScope());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/ValidationUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/ValidationUtil.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2017 Sun Microsystems, Inc., Kohsuke Kawaguchi, Yahoo! Inc., Peter Hayes, Tom Huybrechts, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.matrixauth;
+
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Stapler;
+
+@Restricted(NoExternalUse.class)
+class ValidationUtil {
+    private ValidationUtil() {
+        // do not use
+    }
+
+    public static String formatNonExistentUserGroupValidationResponse(String user, String tooltip) {
+        return formatUserGroupValidationResponse("user-disabled.png", "<span style='text-decoration: line-through; color: grey;'>" + user + "</span>", tooltip, true);
+    }
+
+    public static String formatUserGroupValidationResponse(String img, String user, String tooltip, boolean inPlugin) {
+        if (inPlugin) {
+            return String.format("<span title='%s'><img src='%s/plugin/matrix-auth/images/%s' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), img, user);
+        } else {
+            return String.format("<span title='%s'><img src='%s%s/images/16x16/%s' style='margin-right:0.2em'>%s</span>", tooltip, Stapler.getCurrentRequest().getContextPath(), Jenkins.RESOURCE_PATH, img, user);
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.jelly
@@ -23,6 +23,6 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:description>${%blurb(rootURL)}</f:description>
 </j:jelly>


### PR DESCRIPTION
Extract an interface with default method implementations common to the strategy and the properties (as opposed to the existing one that only did code common to properties), an interface for their descriptors, and a new abstract converter.

Untested.