### PR TITLE
Add ignores for maven-release-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ build/
 
 # VS Code
 .vscode/
+
+# maven-release-plugin
+pom.xml.releaseBackup
+release.properties


### PR DESCRIPTION
I expect this to take care of these lines in the release build output:

    [WARNING] Ignoring unrecognized line: ?? pom.xml.releaseBackup
    [WARNING] Ignoring unrecognized line: ?? release.properties
