### PR TITLE
Don't show a warning when cloudbees-folder is missing

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -200,7 +200,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
     /**
      * Ensure that the user creating a folder has Read and Configure permissions
      */
-    @Extension
+    @Extension(optional = true)
     @Restricted(NoExternalUse.class)
     public static class ItemListenerImpl extends ItemListener {
         @Override


### PR DESCRIPTION
This extension was added in 2.0, but I forgot to mark it `optional = true`.