### PR TITLE
[JENKINS-47555] Fix test on 2.73.2+

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodePropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodePropertyTest.java
@@ -52,6 +52,11 @@ public class AuthorizationMatrixNodePropertyTest {
         ProjectMatrixAuthorizationStrategy authorizationStrategy = new ProjectMatrixAuthorizationStrategy();
         authorizationStrategy.add(Computer.CREATE, "alice");
         authorizationStrategy.add(Jenkins.READ, "alice");
+
+        { // createSlave uses CommandLauncher, which requires RUN_SCRIPTS since 2.73.2
+            authorizationStrategy.add(Jenkins.RUN_SCRIPTS, "alice");
+            ProjectMatrixAuthorizationStrategy.ENABLE_DANGEROUS_PERMISSIONS = true;
+        }
         r.jenkins.setAuthorizationStrategy(authorizationStrategy);
 
         Node node;


### PR DESCRIPTION
[JENKINS-47555](https://issues.jenkins-ci.org/browse/JENKINS-47555) by @andresrc 

CC @jglick Perhaps `CommandLauncher` isn't a great default for `JenkinsRule` anymore?