### PR TITLE
Do not perform any checks for System user

### DIFF
--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -71,6 +71,10 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
         return new ACL() {
             @Override
             public boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission permission) {
+                if (a.equals(SYSTEM)) {
+                    return true;
+                }
+
                 return child.hasPermission(a, permission) || parent.hasPermission(a, permission);
             }
         };


### PR DESCRIPTION
According the Jenkins Core docs in case of SYSTEM user we should assume
that it can do whatever he wants.

p.s. The original problem comes from `getPlugin` method that is already fixed in Core ( https://github.com/jenkinsci/jenkins/pull/3109)

![screen shot 2017-11-09 at 17 32 51](https://user-images.githubusercontent.com/4785672/32616988-0dd5165c-c574-11e7-9b8c-9a03ed3337b0.png)