### PR TITLE
Add configuration-as-code support with extra contructor

### DIFF
--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -72,7 +72,7 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy imp
     }
 
     /**
-     * Added because of <a href="https://github.com/jenkinsci/configuration-as-code-plugin"/>Configuration as Code plugin</a>
+     * Added because of <a href="https://github.com/jenkinsci/configuration-as-code-plugin">Configuration as Code plugin</a>
      * We can use this constructor to pre-populate a Jenkins instance with a configured permission matrix.
      * @since TODO
      * @param grantedPermissions A map of permission to be granted.

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -64,13 +64,21 @@ import javax.annotation.Nonnull;
 public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy implements AuthorizationContainer {
     private final transient SidACL acl = new AclImpl();
 
+    public GlobalMatrixAuthorizationStrategy() {
+         this.grantedPermissions = new HashMap<>();
+    }
+
+    public GlobalMatrixAuthorizationStrategy(Map<Permission,Set<String>> grantedPermissions) {
+        this.grantedPermissions = new HashMap<>(grantedPermissions);
+    }
+
     /**
      * List up all permissions that are granted.
      *
      * Strings are either the granted authority or the principal,
      * which is not distinguished.
      */
-    private final Map<Permission,Set<String>> grantedPermissions = new HashMap<>();
+    private final Map<Permission,Set<String>> grantedPermissions;
 
     /**
      * List of permissions considered dangerous to grant to non-admin users

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -64,10 +64,19 @@ import javax.annotation.Nonnull;
 public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy implements AuthorizationContainer {
     private final transient SidACL acl = new AclImpl();
 
+    /**
+     * @since TODO
+     */
     public GlobalMatrixAuthorizationStrategy() {
          this.grantedPermissions = new HashMap<>();
     }
 
+    /**
+     * Added because of <a href="https://github.com/jenkinsci/configuration-as-code-plugin"/>Configuration as Code plugin</a>
+     * We can use this constructor to pre-populate a Jenkins instance with a configured permission matrix.
+     * @since TODO
+     * @param grantedPermissions A map of permission to be granted.
+     */
     public GlobalMatrixAuthorizationStrategy(Map<Permission,Set<String>> grantedPermissions) {
         this.grantedPermissions = new HashMap<>(grantedPermissions);
     }

--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -54,8 +54,14 @@ import java.util.TreeSet;
  */
 public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizationStrategy {
 
-    public ProjectMatrixAuthorizationStrategy() { }
+    /**
+     * {@inheritDoc}
+     */
+    public ProjectMatrixAuthorizationStrategy() { super(); }
 
+    /**
+     * {@inheritDoc}
+     */
     public ProjectMatrixAuthorizationStrategy(Map<Permission,Set<String>> grantedPermissions) {
         super(grantedPermissions);
     }

--- a/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -40,6 +40,7 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -52,6 +53,13 @@ import java.util.TreeSet;
  * @author Kohsuke Kawaguchi
  */
 public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizationStrategy {
+
+    public ProjectMatrixAuthorizationStrategy() { }
+
+    public ProjectMatrixAuthorizationStrategy(Map<Permission,Set<String>> grantedPermissions) {
+        super(grantedPermissions);
+    }
+
     @Override
     @Nonnull
     public ACL getACL(@Nonnull Job<?,?> project) {


### PR DESCRIPTION
We do not need to do major work to support c-as-c. Adding an extra constructor enables this.