### PR TITLE
[JENKINS-52167] Rotate permission table header rows in Chrome

### DIFF
--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -100,7 +100,9 @@ THE SOFTWARE.
           <j:forEach var="p" items="${g.permissions}">
             <j:if test="${descriptor.showPermission(p)}">
               <th class="pane" tooltip="${descriptor.getDescription(p)}">
-                ${p.name}
+                <span>
+                  ${p.name}
+                </span>
               </th>
             </j:if>
           </j:forEach>

--- a/src/main/resources/hudson/security/table.css
+++ b/src/main/resources/hudson/security/table.css
@@ -38,8 +38,11 @@
 
 .global-matrix-authorization-strategy-table .caption-row TH {
   font-weight: lighter;
-  writing-mode: tb-rl; /* works in IE, not FF */
   padding: 0;
+}
+
+.global-matrix-authorization-strategy-table .caption-row TH span {
+  writing-mode: vertical-rl;
 }
 
 .global-matrix-authorization-strategy-table TD {


### PR DESCRIPTION
Chrome cannot apply `writing-mode` to `td`, so wrap label in `span` and rotate that.

Before:

> ![screen shot](https://user-images.githubusercontent.com/1831569/41879262-2ad9aa56-78d9-11e8-9993-a995139f54bf.png)

After:

> ![screen shot](https://user-images.githubusercontent.com/1831569/41879266-30aed06e-78d9-11e8-95f3-bfad37ac863e.png)
