### PR TITLE
Add dependency on non-tests classifier version of workflow-cps and incrementalify

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -3,17 +3,20 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>3.25</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Matrix Authorization Strategy Plugin</name>
     <description>Offers matrix-based security authorization strategies (global and per-project).</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+Strategy+Plugin</url>
     <properties>
+        <revision>2.4</revision>
+        <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.60.1</jenkins.version>
         <java.level>8</java.level>
+        <workflow-cps.version>2.30</workflow-cps.version>
     </properties>
     <licenses>
         <license>
@@ -25,7 +28,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>${scmTag}</tag>
   </scm>
     <dependencies>
         <dependency>
@@ -43,7 +46,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.30</version>
+            <version>${workflow-cps.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>${workflow-cps.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/hudson/security/DangerousMatrixPermissionsAdministrativeMonitor.java
+++ b/src/main/java/hudson/security/DangerousMatrixPermissionsAdministrativeMonitor.java
@@ -28,7 +28,7 @@ import hudson.model.AdministrativeMonitor;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -44,7 +44,7 @@ import java.util.List;
  * See also https://jenkins.io/security/advisory/2017-04-10/#matrix-authorization-strategy-plugin-allowed-configuring-dangerous-permissions
  */
 @Extension
-@Restricted(DoNotUse.class)
+@Restricted(NoExternalUse.class)
 public class DangerousMatrixPermissionsAdministrativeMonitor extends AdministrativeMonitor {
     @Override
     public boolean isActivated() {


### PR DESCRIPTION
Although the plugin has an explicit dependency on the `<classifier>tests</classifier>` version of `workflow-cps`, the regular test-scope dependency is pulled in transitively through `workflow-multibranch`. 

This works fine for now since the 2 current versions seem to be compatible, but in the PCT, there can be failures because `SnippitizerTester` (which comes from the `<classifier>tests</classifier>` version of `workflow-cps`) from `workflow-cps` 2.56+ is not compatible with regular `workflow-cps` 2.55-, and the PCT isn't smart enough to update the non-classifier version unless it is specified explicitly here (it updates the `workflow-multibranch` version, but that is not enough).

I also incrementalified the plugin while I was here and fixed the access-modifier issue.