### PR TITLE
[JENKINS-55397] Updating AuthorizationContainerDescriptorTest for new…

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
@@ -18,9 +18,6 @@ import java.util.Locale;
 
 public class AuthorizationContainerDescriptorTest {
 
-    @Rule
-    public JenkinsRule r = new JenkinsRule(); // Needed to check the jenkins version
-
     private Permission TEST_PERMISSION = new Permission(Item.PERMISSIONS, "Test", new Localizable(new ResourceBundleHolder(AuthorizationContainerDescriptorTest.class), "Test"), Item.BUILD, PermissionScope.ITEM);
 
     @Test
@@ -37,14 +34,8 @@ public class AuthorizationContainerDescriptorTest {
             Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Jenkins.PERMISSIONS.title.toString(), Jenkins.ADMINISTER.name)));
         }
 
-        { // Item.CANCEL is implied by Item.BUILD until 2.119. From 2.120 is implied by Permission.UPDATE, so the description changes.
-            String description = new GlobalMatrixAuthorizationStrategy.DescriptorImpl().getDescription(Item.CANCEL);
-            Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy()));
-            Assert.assertEquals(Jenkins.getVersion().isOlderThan(new VersionNumber("2.120")), description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Item.PERMISSIONS.title.toString(), Item.BUILD.name)));
-        }
-
         {
-            // Use a fake permission for the 'implied by' message addition check, since Item.CANCEL changed behavior in 2.120.
+            // Use a fake permission for the 'implied by' message addition check, since Item.CANCEL changed behavior in 2.120, and there's no permission left with the same behavior.
             String description = new GlobalMatrixAuthorizationStrategy.DescriptorImpl().getDescription(TEST_PERMISSION);
             Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy()));
             Assert.assertTrue(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Item.PERMISSIONS.title.toString(), Item.BUILD.name)));

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
@@ -21,7 +21,7 @@ public class AuthorizationContainerDescriptorTest {
     @Rule
     public JenkinsRule r = new JenkinsRule(); // Needed to check the jenkins version
 
-    private Permission FAKE = new Permission(Item.PERMISSIONS, "Fake", new TestLocalizable(), Item.BUILD, PermissionScope.ITEM);
+    private Permission TEST_PERMISSION = new Permission(Item.PERMISSIONS, "Test", new Localizable(new ResourceBundleHolder(AuthorizationContainerDescriptorTest.class), "Test"), Item.BUILD, PermissionScope.ITEM);
 
     @Test
     public void testImpliedNotes() {
@@ -44,32 +44,10 @@ public class AuthorizationContainerDescriptorTest {
         }
 
         {
-            String description = new GlobalMatrixAuthorizationStrategy.DescriptorImpl().getDescription(FAKE);
+            // Use a fake permission for the 'implied by' message addition check, since Item.CANCEL changed behavior in 2.120.
+            String description = new GlobalMatrixAuthorizationStrategy.DescriptorImpl().getDescription(TEST_PERMISSION);
             Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy()));
             Assert.assertTrue(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Item.PERMISSIONS.title.toString(), Item.BUILD.name)));
-        }
-    }
-
-    private static class TestLocalizable extends Localizable {
-        private static final String MSG = "This permission has been created for this test class";
-
-        public TestLocalizable() {
-            super(null, "key", new Object[0]);
-        }
-
-        @Override
-        public String getKey() {
-            return "key";
-        }
-
-        @Override
-        public String toString(Locale locale) {
-            return MSG;
-        }
-
-        @Override
-        public String toString() {
-            return MSG;
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
@@ -3,11 +3,18 @@ package org.jenkinsci.plugins.matrixauth;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public class AuthorizationContainerDescriptorTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule(); // Needed to check the jenkins version
+
     @Test
     public void testImpliedNotes() {
         { // no message on Administer
@@ -22,10 +29,10 @@ public class AuthorizationContainerDescriptorTest {
             Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Jenkins.PERMISSIONS.title.toString(), Jenkins.ADMINISTER.name)));
         }
 
-        { // Item.CANCEL is implied by Item.BUILD (at least up to core 2.111)
+        { // Item.CANCEL is implied by Item.BUILD until 2.119. From 2.120 is implied by Permission.UPDATE, so the description changes.
             String description = new GlobalMatrixAuthorizationStrategy.DescriptorImpl().getDescription(Item.CANCEL);
             Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy()));
-            Assert.assertTrue(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Item.PERMISSIONS.title.toString(), Item.BUILD.name)));
+            Assert.assertEquals(Jenkins.getVersion().isOlderThan(new VersionNumber("2.120")), description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Item.PERMISSIONS.title.toString(), Item.BUILD.name)));
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.java
@@ -3,17 +3,25 @@ package org.jenkinsci.plugins.matrixauth;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.security.PermissionScope;
 import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.localizer.Localizable;
+import org.jvnet.localizer.ResourceBundleHolder;
+
+import java.util.Locale;
 
 public class AuthorizationContainerDescriptorTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule(); // Needed to check the jenkins version
+
+    private Permission FAKE = new Permission(Item.PERMISSIONS, "Fake", new TestLocalizable(), Item.BUILD, PermissionScope.ITEM);
 
     @Test
     public void testImpliedNotes() {
@@ -33,6 +41,35 @@ public class AuthorizationContainerDescriptorTest {
             String description = new GlobalMatrixAuthorizationStrategy.DescriptorImpl().getDescription(Item.CANCEL);
             Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy()));
             Assert.assertEquals(Jenkins.getVersion().isOlderThan(new VersionNumber("2.120")), description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Item.PERMISSIONS.title.toString(), Item.BUILD.name)));
+        }
+
+        {
+            String description = new GlobalMatrixAuthorizationStrategy.DescriptorImpl().getDescription(FAKE);
+            Assert.assertFalse(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionNotImpliedBy()));
+            Assert.assertTrue(description.contains(Messages.GlobalMatrixAuthorizationStrategy_PermissionImpliedBy(Item.PERMISSIONS.title.toString(), Item.BUILD.name)));
+        }
+    }
+
+    private static class TestLocalizable extends Localizable {
+        private static final String MSG = "This permission has been created for this test class";
+
+        public TestLocalizable() {
+            super(null, "key", new Object[0]);
+        }
+
+        @Override
+        public String getKey() {
+            return "key";
+        }
+
+        @Override
+        public String toString(Locale locale) {
+            return MSG;
+        }
+
+        @Override
+        public String toString() {
+            return MSG;
         }
     }
 }

--- a/src/test/resources/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.properties
+++ b/src/test/resources/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptorTest.properties
@@ -1,0 +1,1 @@
+Test = Test description


### PR DESCRIPTION
See [JENKINS-55397](https://issues.jenkins-ci.org/browse/JENKINS-55397)

Using newer core versions (starting at 2.120),` AuthorizationContainerDescriptorTest#testImpliedNotes` is falling in the PCT. The error is caused by [this change](https://github.com/jenkinsci/jenkins/commit/081e400a5b618b035fa9c350e3bf4341d66e2476). From then, the `Item.CANCEL` permission is not imply by `BUILD` but by `Permission.UPDATE`, so its description changes. Having made a research, it seems that only the description text is affected, so the plugin is still compatible with Jenkins-core and only the test should be updated.

@reviewbybees 
@daniel-beck as maintainer
@raul-arabaolaza who found the issue