### PR TITLE
Java 11 readiness

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.25</version>
+        <version>3.42</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>${revision}${changelist}</version>

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
@@ -67,7 +67,7 @@ public interface AuthorizationContainer {
 
     /**
      * Works like {@link #add(Permission, String)} but takes both parameters
-     * from a single string of the form <tt>PERMISSIONID:sid</tt>
+     * from a single string of the form <code>PERMISSIONID:sid</code>
      */
     @Restricted(NoExternalUse.class)
     default void add(String shortForm) {


### PR DESCRIPTION
For Java 11 readiness, apply recommended configuration:
https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime

And fixing what was revealed through this.

@jenkinsci/java11-support 