### PR TITLE
Update AuthorizationContainerDescriptor.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
@@ -138,7 +138,7 @@ public interface AuthorizationContainerDescriptor<T extends AuthorizationContain
         try {
             try {
                 sr.loadUserByUsername(v);
-                User u = User.get(v, false, Collections.emptyMap());
+                User u = User.get(v, true, Collections.emptyMap());
                 if (ev.equals(u.getFullName())) {
                     return FormValidation.respond(FormValidation.Kind.OK, formatUserGroupValidationResponse("person.png", ev, "User", false));
                 }


### PR DESCRIPTION
create false produces ugly NPEs in den GUI, that only resolve if the user logs into Jenkins.

Tested with Jenkins 2.164.2, Pluginversion 2.4.1

We use Atlassian Crowd as authentification provider!

![npe](https://user-images.githubusercontent.com/24733065/57061682-11d0e680-6cbe-11e9-91c9-e2aaf3813f7c.png)
