### PR TITLE
Cache implying permissions for `hasPermission()` checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>3.47</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>${revision}${changelist}</version>

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
@@ -42,6 +42,8 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.jenkinsci.plugins.matrixauth.ImplyingPermissionsCache.getImplyingPermissions;
+
 @Restricted(NoExternalUse.class)
 public interface AuthorizationContainer {
 
@@ -130,15 +132,15 @@ public interface AuthorizationContainer {
     /**
      * Checks if the given SID has the given permission.
      */
-    default boolean hasPermission(String sid, Permission p) {
+    default boolean hasPermission(String sid, Permission permission) {
         if (!GlobalMatrixAuthorizationStrategy.ENABLE_DANGEROUS_PERMISSIONS
-                && GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS.contains(p)) {
+                && GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS.contains(permission)) {
             return hasPermission(sid, Jenkins.ADMINISTER);
         }
         final SecurityRealm securityRealm = Jenkins.get().getSecurityRealm();
         final IdStrategy groupIdStrategy = securityRealm.getGroupIdStrategy();
         final IdStrategy userIdStrategy = securityRealm.getUserIdStrategy();
-        for (; p != null; p = p.impliedBy) {
+        for (Permission p : getImplyingPermissions(permission)) {
             if (!p.getEnabled()) {
                 continue;
             }
@@ -161,14 +163,14 @@ public interface AuthorizationContainer {
     /**
      * Checks if the given SID has the given permission.
      */
-    default boolean hasPermission(String sid, Permission p, boolean principal) {
+    default boolean hasPermission(String sid, Permission permission, boolean principal) {
         if (!GlobalMatrixAuthorizationStrategy.ENABLE_DANGEROUS_PERMISSIONS
-                && GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS.contains(p)) {
+                && GlobalMatrixAuthorizationStrategy.DANGEROUS_PERMISSIONS.contains(permission)) {
             return hasPermission(sid, Jenkins.ADMINISTER, principal);
         }
         final SecurityRealm securityRealm = Jenkins.get().getSecurityRealm();
         final IdStrategy strategy = principal ? securityRealm.getUserIdStrategy() : securityRealm.getGroupIdStrategy();
-        for (; p != null; p = p.impliedBy) {
+        for (Permission p : getImplyingPermissions(permission)) {
             if (!p.getEnabled()) {
                 continue;
             }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/ImplyingPermissionsCache.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/ImplyingPermissionsCache.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.matrixauth;
+
+import hudson.security.Permission;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Caches implying permissions for fast future access.
+ *
+ * The cache is built up when this class is loaded.
+ */
+class ImplyingPermissionsCache {
+    private static ConcurrentHashMap<Permission, Set<Permission>> implyingPermissionCache;
+
+    static {
+        implyingPermissionCache = new ConcurrentHashMap<>();
+        Permission.getAll().forEach(ImplyingPermissionsCache::calculateAndCacheImplyingPermissions);
+    }
+
+    private static Set<Permission> calculateAndCacheImplyingPermissions(Permission perm) {
+        Set<Permission> implyingPermissions = new HashSet<>();
+        for (Permission p = perm; p != null; p = p.impliedBy) {
+            implyingPermissions.add(p);
+        }
+        implyingPermissionCache.put(perm, implyingPermissions);
+        return implyingPermissions;
+    }
+
+    private ImplyingPermissionsCache() {
+    }
+
+    /**
+     * Returns the set of permissions that imply the permission {@code p}.
+     *
+     * @param p the permission
+     * @return set of permissions that imply this permission
+     */
+    static Set<Permission> getImplyingPermissions(Permission p) {
+        Set<Permission> permissions = implyingPermissionCache.get(p);
+        if (permissions != null) {
+            permissions = calculateAndCacheImplyingPermissions(p);
+        }
+        return permissions;
+    }
+}


### PR DESCRIPTION
Caches implying permissions for improving performance of `hasPermission()` checks.

This pull request follows from https://github.com/jenkinsci/role-strategy-plugin/pull/83 where we saw large improvements in performance of `hasPermission()` calls.

@jenkinsci/gsoc2019-role-strategy 