### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Matrix Authorization Strategy Plugin</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+Strategy+Plugin</url>
+    <url>https://github.com/jenkinsci/matrix-auth-plugin</url>
     <properties>
         <revision>2.4.3</revision>
         <changelist>-SNAPSHOT</changelist>


### PR DESCRIPTION
There is nothing left on the Wiki Page except changelog, so we can safely replace it by GitHub page.

See https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A