### PR TITLE
Increase core dependency to 2.164.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <revision>2.6</revision>
         <changelist>-SNAPSHOT</changelist>
         <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
         <workflow-cps.version>2.30</workflow-cps.version>
         <configuration-as-code.version>1.12</configuration-as-code.version>


### PR DESCRIPTION
Will get rid of the implied dependency on https://plugins.jenkins.io/jaxb

Per http://stats.jenkins.io/pluginversions/matrix-auth.html users are on that release already anyway.