### PR TITLE
Update core dependency to 2.190.1

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Duse-jenkins-bom

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Some examples:
 
 ### Upcoming Changes
 
-* Increase minimum required Jenkins version to 2.164.1
+* Increase minimum required Jenkins version to 2.190.1 to have fewer implied plugin dependencies
 
 ### Version 2.5 (2019-10-14)
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.55</version>
+        <version>3.56</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>${revision}${changelist}</version>
@@ -15,7 +15,7 @@
         <revision>2.6</revision>
         <changelist>-SNAPSHOT</changelist>
         <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
-        <jenkins.version>2.164.1</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <java.level>8</java.level>
         <workflow-cps.version>2.30</workflow-cps.version>
         <configuration-as-code.version>1.35</configuration-as-code.version>
@@ -30,8 +30,8 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>${scmTag}</tag>
-  </scm>
+        <tag>${scmTag}</tag>
+     </scm>
     <dependencies>
         <!-- optional plugin dependencies -->
         <dependency>
@@ -92,7 +92,7 @@
             <version>1.76</version>
             <scope>test</scope>
             <exclusions>
-                <!-- needed for -Djenkins.version=2.164.1 -->
+                <!-- Diverged from core version of Groovy -->
                 <exclusion>
                     <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy-all</artifactId>


### PR DESCRIPTION
2.190.x is the baseline that comes without implied dependencies at the moment: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/split-plugins.txt

Jenkins BOM is needed for an slf4j upper bounds problem with the new core.