### PR TITLE
[JENKINS-36625] Allow wrap of user/group names

### DIFF
--- a/src/main/resources/hudson/security/table.css
+++ b/src/main/resources/hudson/security/table.css
@@ -52,7 +52,6 @@
 .global-matrix-authorization-strategy-table TD.left-most {
   text-align: left;
   border-left: none;
-  white-space: nowrap;
 }
 
 .global-matrix-authorization-strategy-table TD.stop {


### PR DESCRIPTION
This should help a little, but I think the main problem is in core…

## Before

![Screenshot before](https://user-images.githubusercontent.com/1831569/74597765-dcd32c00-5064-11ea-9c82-676a3dc48f32.png)

## After

![Screenshot after](https://user-images.githubusercontent.com/1831569/74597761-d775e180-5064-11ea-8b20-662d505770e4.png)