### PR TITLE
[JENKINS-62202] Fix accidental read-only mode in jobs and folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 2.6.1 (TBD)
+
+* [JENKINS-62202](https://issues.jenkins-ci.org/browse/JENKINS-62202):
+  Fix regression introduced in 2.6 that disabled per-job/folder/agent configuration UI for users without Overall/Administer.
+
 ## Version 2.6 (2020-04-30)
 
 * Increase minimum required Jenkins version to 2.222.1.

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -127,6 +127,11 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
         return Collections.unmodifiableMap(grantedPermissions);
     }
 
+    @Override
+    public Permission getEditingPermission() {
+        return Item.CONFIGURE;
+    }
+
     /**
      * Adds to {@link #grantedPermissions}. Use of this method should be limited
      * during construction, as this object itself is considered immutable once

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -145,6 +145,11 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
         return Collections.unmodifiableMap(grantedPermissions);
     }
 
+    @Override
+    public Permission getEditingPermission() {
+        return Item.CONFIGURE;
+    }
+
     /**
      * Adds to {@link #grantedPermissions}. Use of this method should be limited
      * during construction, as this object itself is considered immutable once

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -107,6 +107,11 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy imp
     }
 
     @Override
+    public Permission getEditingPermission() {
+        return Jenkins.ADMINISTER;
+    }
+
+    @Override
     @Nonnull
     public ACL getRootACL() {
         return acl;

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
@@ -91,6 +91,9 @@ public interface AuthorizationContainer {
         add(p, shortForm.substring(idx + 1));
     }
 
+    @Restricted(NoExternalUse.class)
+    Permission getEditingPermission();
+
     /**
      * Returns all SIDs configured in this matrix, minus "anonymous"
      *

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -103,6 +103,11 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
         return Collections.unmodifiableMap(grantedPermissions);
     }
 
+    @Override
+    public Permission getEditingPermission() {
+        return Computer.CONFIGURE;
+    }
+
     public void setInheritanceStrategy(InheritanceStrategy inheritanceStrategy) {
         this.inheritanceStrategy = inheritanceStrategy;
     }

--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -60,7 +60,7 @@ THE SOFTWARE.
             </j:if>
           </j:forEach>
         </j:forEach>
-        <l:isAdmin>
+        <l:hasPermission permission="${instance.getEditingPermission()}">
           <td class="stop" style="text-align:left;">
             <a href="#" class="selectall">
               <img alt="${%Select all}" title="${%selectall(attrs.sid)}" src="${rootURL}/plugin/matrix-auth/images/16x16/select-all.png" height="16" width="16"/>
@@ -74,7 +74,7 @@ THE SOFTWARE.
               </a>
             </j:if>
           </td>
-        </l:isAdmin>
+        </l:hasPermission>
       </d:tag>
     </d:taglib>
     <link rel="stylesheet" href="${rootURL}${app.VIEW_RESOURCE_PATH}/hudson/security/table.css" type="text/css" />
@@ -98,7 +98,9 @@ THE SOFTWARE.
             ${g.title}
           </td>
         </j:forEach>
-        <td rowspan="2" class="stop" />
+        <l:hasPermission permission="${instance.getEditingPermission()}">
+          <td rowspan="2" class="stop" />
+        </l:hasPermission>
       </tr>
       <!-- The second row for individual permission -->
       <tr class="caption-row">
@@ -136,7 +138,7 @@ THE SOFTWARE.
         <local:row sid="__SID__" />
       </tr>
     </table>
-    <l:isAdmin>
+    <l:hasPermission permission="${instance.getEditingPermission()}">
       <table style="margin-top:0.5em; margin-left: 2em; width: 100%">
        <tr>
          <td colspan="3">
@@ -147,7 +149,7 @@ THE SOFTWARE.
        </td></tr>
        <f:helpArea />
       </table>
-    </l:isAdmin>
+    </l:hasPermission>
     <script>
       //<![CDATA[
       Behaviour.specify("#${id}button", 'GlobalMatrixAuthorizationStrategy', 0, function(e) {

--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -27,6 +27,26 @@ THE SOFTWARE.
     <j:set var="groups" value="${descriptor.allGroups}"/>
     <d:taglib uri="local">
       <!-- generate one row for the sid name @sid -->
+      <d:tag name="isEditable">
+        <l:hasPermission permission="${instance.getEditingPermission()}">
+          <j:if test="${readOnlyMode == null or not readOnlyMode}">
+            <!--
+            While the permission check should be good enough, we do both checks to catch exceptions like node
+            properties configured for cloud templates (once https://github.com/jenkinsci/jenkins/pull/4531 is merged):
+            A user with Overall/SystemRead can view the form and with global Computer/Configure the user also passes the
+            permission check. The user still isn't able to configure the cloud, so we want this to be disabled anyway.
+
+            readOnlyMode is null when the form doesn't set the flag:
+
+              - regular (freestyle) job configuration forms before Jenkins 2.223.
+              - folder configuration at least up to cloudbees-folder 6.12 (JENKINS-62218)
+
+            In that case, show the UI element.
+            -->
+            <d:invokeBody/>
+          </j:if>
+        </l:hasPermission>
+      </d:tag>
       <d:tag name="row">
         <j:choose>
           <j:when test="${attrs.sid == 'authenticated'}">
@@ -60,7 +80,7 @@ THE SOFTWARE.
             </j:if>
           </j:forEach>
         </j:forEach>
-        <l:hasPermission permission="${instance.getEditingPermission()}">
+        <local:isEditable>
           <td class="stop" style="text-align:left;">
             <a href="#" class="selectall">
               <img alt="${%Select all}" title="${%selectall(attrs.sid)}" src="${rootURL}/plugin/matrix-auth/images/16x16/select-all.png" height="16" width="16"/>
@@ -74,7 +94,7 @@ THE SOFTWARE.
               </a>
             </j:if>
           </td>
-        </l:hasPermission>
+        </local:isEditable>
       </d:tag>
     </d:taglib>
     <link rel="stylesheet" href="${rootURL}${app.VIEW_RESOURCE_PATH}/hudson/security/table.css" type="text/css" />
@@ -98,9 +118,9 @@ THE SOFTWARE.
             ${g.title}
           </td>
         </j:forEach>
-        <l:hasPermission permission="${instance.getEditingPermission()}">
+        <local:isEditable>
           <td rowspan="2" class="stop" />
-        </l:hasPermission>
+        </local:isEditable>
       </tr>
       <!-- The second row for individual permission -->
       <tr class="caption-row">
@@ -138,7 +158,7 @@ THE SOFTWARE.
         <local:row sid="__SID__" />
       </tr>
     </table>
-    <l:hasPermission permission="${instance.getEditingPermission()}">
+    <local:isEditable>
       <table style="margin-top:0.5em; margin-left: 2em; width: 100%">
        <tr>
          <td colspan="3">
@@ -149,8 +169,7 @@ THE SOFTWARE.
        </td></tr>
        <f:helpArea />
       </table>
-    </l:hasPermission>
-    <script>
+      <script>
       //<![CDATA[
       Behaviour.specify("#${id}button", 'GlobalMatrixAuthorizationStrategy', 0, function(e) {
         makeButton($$('${id}button'), function (e) {
@@ -236,11 +255,6 @@ THE SOFTWARE.
         e.disabled = false;
         e.setAttribute('tooltip', findAncestor(e, "TD").getAttribute('data-tooltip-enabled'));
 
-        var submitButtonPresent = document.getElementsByClassName("submit-button").length > 0;
-        if (!submitButtonPresent) { // readonly mode if there's no submit button (Jenkins 2.222+)
-            e.disabled = true;
-            return;
-        }
         for (var i = 0; i < impliedByList.length; i++) {
           var permissionId = impliedByList[i];
           var reference = tr.querySelector("td[data-permission-id='" + permissionId + "'] input");
@@ -273,6 +287,7 @@ THE SOFTWARE.
           }
         });
         //]]>
-    </script>
+      </script>
+    </local:isEditable>
   </f:block>
 </j:jelly>

--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -28,24 +28,32 @@ THE SOFTWARE.
     <d:taglib uri="local">
       <!-- generate one row for the sid name @sid -->
       <d:tag name="isEditable">
-        <l:hasPermission permission="${instance.getEditingPermission()}">
-          <j:if test="${readOnlyMode == null or not readOnlyMode}">
+        <j:choose>
+          <j:when test="${readOnlyMode == null}">
+            <l:hasPermission permission="${instance.getEditingPermission()}">
+              <!--
+              While a permission check should be good enough, we prefer readOnlyMode to catch exceptions like node
+              properties configured for cloud templates (once https://github.com/jenkinsci/jenkins/pull/4531 is merged):
+              A user with Overall/SystemRead can view the form and with global Computer/Configure the user also passes the
+              permission check. The user still isn't able to configure the cloud, so we want this to be disabled anyway.
+
+              readOnlyMode is null when the form doesn't set the flag:
+
+                - regular (freestyle) job configuration forms before Jenkins 2.223.
+                - folder configuration at least up to cloudbees-folder 6.12 (JENKINS-62218)
+
+              In that case, check for the applicable permission.
+              -->
+            <d:invokeBody/>
+            </l:hasPermission>
+          </j:when>
+          <j:when test="${not readOnlyMode}">
             <!--
-            While the permission check should be good enough, we do both checks to catch exceptions like node
-            properties configured for cloud templates (once https://github.com/jenkinsci/jenkins/pull/4531 is merged):
-            A user with Overall/SystemRead can view the form and with global Computer/Configure the user also passes the
-            permission check. The user still isn't able to configure the cloud, so we want this to be disabled anyway.
-
-            readOnlyMode is null when the form doesn't set the flag:
-
-              - regular (freestyle) job configuration forms before Jenkins 2.223.
-              - folder configuration at least up to cloudbees-folder 6.12 (JENKINS-62218)
-
-            In that case, show the UI element.
+            Allow explicitly setting readOnlyMode = false to render with editing controls despite possible lack of permissions.
             -->
             <d:invokeBody/>
-          </j:if>
-        </l:hasPermission>
+          </j:when>
+        </j:choose>
       </d:tag>
       <d:tag name="row">
         <j:choose>

--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
 
               In that case, check for the applicable permission.
               -->
-            <d:invokeBody/>
+              <d:invokeBody/>
             </l:hasPermission>
           </j:when>
           <j:when test="${not readOnlyMode}">
@@ -170,7 +170,7 @@ THE SOFTWARE.
       <table style="margin-top:0.5em; margin-left: 2em; width: 100%">
        <tr>
          <td colspan="3">
-              <input type="button" value="${%Add user or group…}" id="${id}button"/>
+            <input type="button" class="matrix-auth-add-user-button" value="${%Add user or group…}" id="${id}button"/>
          </td>
          <td align="right">
         <a href="#" class="help-button" helpURL="${rootURL}${descriptor.find('hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl').getHelpFile('user-group')}"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/ReadOnlyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/ReadOnlyTest.java
@@ -104,9 +104,9 @@ public class ReadOnlyTest {
     }
 
     @Test
-    @Ignore
+    @Ignore // TODO this form is only accessible to Agent/ExtendedRead users from https://github.com/jenkinsci/jenkins/pull/4531
     public void testAgentConfiguration() throws Exception {
-        Assume.assumeTrue(Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.234"))); // TODO this form is only accessible to Agent/ExtendedRead users from https://github.com/jenkinsci/jenkins/pull/4531
+        Assume.assumeTrue(Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.234"))); // TODO fix version
         final Slave agent = j.createSlave();
         agent.setNodeProperties(Collections.singletonList(new AuthorizationMatrixNodeProperty()));
         assertPresentAndReadOnly( "computer/" + agent.getNodeName() + "/configure");

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/ReadOnlyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/ReadOnlyTest.java
@@ -1,0 +1,124 @@
+package org.jenkinsci.plugins.matrixauth;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.Computer;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.Slave;
+import hudson.security.AuthorizationMatrixProperty;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Objects;
+
+@Issue("JENKINS-62202")
+public class ReadOnlyTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private static boolean containsClassName(String className, String value) {
+        Objects.requireNonNull(className, "className");
+        Objects.requireNonNull(value, "value");
+        return value.equals(className) || value.startsWith(className + " ") || value.endsWith(" " + className) || value.contains(" " + className + " ");
+    }
+
+    private static boolean hasTagWithClassInPage(HtmlPage page, String tagName, String className) {
+        return page.getElementsByTagName(tagName).stream().anyMatch( it -> containsClassName(className, it.getAttribute("class")));
+    }
+
+    private HtmlPage initAndAssertPresent(String configurationUrl) throws IOException, SAXException {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        final HtmlPage page = wc.goTo(configurationUrl);
+        Assert.assertTrue("contains permission container", hasTagWithClassInPage(page, "table", "global-matrix-authorization-strategy-table"));
+        return page;
+    }
+
+    private void assertPresentAndEditable(String configurationUrl) throws IOException, SAXException {
+        final HtmlPage page = initAndAssertPresent(configurationUrl);
+        Assert.assertTrue("should contain add group/user button", hasTagWithClassInPage(page, "span", "matrix-auth-add-user-button")); // Behavior.specify / makeButton converts input to button and wraps it in span
+    }
+
+    private void assertPresentAndReadOnly(String configurationUrl) throws IOException, SAXException {
+        final HtmlPage page = initAndAssertPresent(configurationUrl);
+        Assert.assertFalse("should not contain add group/user button", hasTagWithClassInPage(page, "span", "matrix-auth-add-user-button")); // Behavior.specify / makeButton converts input to button and wraps it in span
+    }
+
+    @Before
+    public void prepare() throws Exception {
+        Jenkins.SYSTEM_READ.enabled = true;
+        Item.EXTENDED_READ.enabled = true;
+        Computer.EXTENDED_READ.enabled = true;
+        Jenkins.get().setSecurityRealm(j.createDummySecurityRealm());
+        final ProjectMatrixAuthorizationStrategy strategy = new ProjectMatrixAuthorizationStrategy();
+        {
+            strategy.add(Jenkins.READ, "anonymous");
+            strategy.add(Jenkins.SYSTEM_READ, "anonymous");
+            strategy.add(Item.READ, "anonymous");
+            strategy.add(Item.EXTENDED_READ, "anonymous");
+            strategy.add(Computer.EXTENDED_READ, "anonymous");
+        }
+        Jenkins.get().setAuthorizationStrategy(strategy);
+    }
+
+    @Test
+    public void testGlobalConfiguration() throws IOException, SAXException {
+        Assume.assumeTrue(Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.223"))); // this form is only accessible to Overall/SystemRead users from 2.223+
+        assertPresentAndReadOnly("configureSecurity");
+
+        ((ProjectMatrixAuthorizationStrategy)Jenkins.get().getAuthorizationStrategy()).add(Jenkins.ADMINISTER, "anonymous");
+        assertPresentAndEditable("configureSecurity");
+    }
+
+    @Test
+    public void testJobConfiguration() throws IOException, SAXException {
+        final FreeStyleProject job = j.createFreeStyleProject(); // While 2.223 changed the UI (readOnlyMode), the basic behavior by this plugin remains the same due to permission check
+        job.addProperty(new AuthorizationMatrixProperty(Collections.emptyMap()));
+        assertPresentAndReadOnly(job.getUrl() + "configure");
+
+        job.removeProperty(AuthorizationMatrixProperty.class);
+        job.addProperty(new AuthorizationMatrixProperty(Collections.singletonMap(Item.CONFIGURE, Collections.singleton(Jenkins.ANONYMOUS.getName()))));
+        assertPresentAndEditable(job.getUrl() + "configure");
+    }
+
+    @Test
+    public void testFolderConfiguration() throws IOException, SAXException {
+        final Folder folder = Jenkins.get().createProject(Folder.class, "testFolder");
+        folder.addProperty(new com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty(Collections.emptyMap()));
+        assertPresentAndReadOnly(folder.getUrl() + "configure");
+
+        folder.getProperties().replace(new com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty(Collections.singletonMap(Item.CONFIGURE, Collections.singleton(Jenkins.ANONYMOUS.getName()))));
+        assertPresentAndEditable(folder.getUrl() + "configure");
+    }
+
+    @Test
+    @Ignore
+    public void testAgentConfiguration() throws Exception {
+        Assume.assumeTrue(Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.234"))); // TODO this form is only accessible to Agent/ExtendedRead users from https://github.com/jenkinsci/jenkins/pull/4531
+        final Slave agent = j.createSlave();
+        agent.setNodeProperties(Collections.singletonList(new AuthorizationMatrixNodeProperty()));
+        assertPresentAndReadOnly( "computer/" + agent.getNodeName() + "/configure");
+
+        // Grant permission globally -- works with https://github.com/jenkinsci/jenkins/pull/4531 before https://github.com/jenkinsci/jenkins/pull/4531#pullrequestreview-408283044
+        ((ProjectMatrixAuthorizationStrategy)Jenkins.get().getAuthorizationStrategy()).add(Computer.CONFIGURE, "anonymous");
+
+        // Grant per-agent permission -- https://github.com/jenkinsci/jenkins/pull/4531#pullrequestreview-408283044 prevents this so far
+// TODO use this once it works upstream
+//        final AuthorizationMatrixNodeProperty prop = new AuthorizationMatrixNodeProperty();
+//        prop.add(Computer.CONFIGURE, Jenkins.ANONYMOUS.getName());
+//        agent.setNodeProperties(Collections.singletonList(prop));
+        assertPresentAndEditable( "computer/" + agent.getNodeName() + "/configure");
+    }
+}


### PR DESCRIPTION
…gurations

----

[JENKINS-62202](https://issues.jenkins-ci.org/browse/JENKINS-62202)

Regression because of https://github.com/jenkinsci/matrix-auth-plugin/pull/78

### Testing notes

Enable permissions involved like this:

```
Item.EXTENDED_READ.enabled = true
Jenkins.SYSTEM_READ.enabled = true
Computer.EXTENDED_READ.enabled = true
```

`mvn hpi:run -Djenkins.version=2.235` helps some, but Computer/Configure can only be confirmed with https://github.com/jenkinsci/jenkins/pull/4531.

Manual testing setup:

1. `docker run --rm -ti -p 8080:8080 -e ID=4531 jenkins/core-pr-tester`
2. In Setup Wizard, install _only_ Folders Plugin
3. Create admin user
4. In Plugin Manager » Advanced, upload PR build
5. Create Manage Users, create user/user
6. In Script Console, run the script above

Now permissions can be assigned at different levels to ensure this works as intended.