### PR TITLE
Fix case sensitivity issue for LDAP logins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java
@@ -125,7 +125,7 @@ public interface AuthorizationContainer {
             if (set == null) {
                 continue;
             }
-            if (set.contains(sid)) {
+            if (set.stream().anyMatch(sid.trim()::equalsIgnoreCase)) {
                 return true;
             }
             for (String s: set) {


### PR DESCRIPTION
Fix case sensitivity issue between LDAP plugin and matrix-auth plugin. Basically logging in with UPERCASE or CamelCase is allowed in LDAP however the matrix-auth plugin does not apply the same permissions.