### PR TITLE
Making PermissionAdderTest run in PCT

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
@@ -36,9 +36,11 @@ public class PermissionAdderTest {
                 signup.enterUsername("alice");
                 signup.enterPassword("alice");
                 signup.enterFullName("Alice User");
+                signup.enterEmail("alice@nowhere.net");
                 signup.submit(r.j);
-
-                Assert.assertTrue(r.j.jenkins.getACL().hasPermission(User.get("alice", false, Collections.emptyMap()).impersonate(), Jenkins.ADMINISTER));
+                User alice = User.get("alice", false, Collections.emptyMap());
+                Assert.assertNotNull(alice);
+                Assert.assertTrue(r.j.jenkins.getACL().hasPermission(alice.impersonate(), Jenkins.ADMINISTER));
             }
         });
         r.addStep(new Statement() {

--- a/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
@@ -8,6 +8,7 @@ import jenkins.model.Jenkins;
 
 import java.util.Collections;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +37,11 @@ public class PermissionAdderTest {
                 signup.enterUsername("alice");
                 signup.enterPassword("alice");
                 signup.enterFullName("Alice User");
-                signup.enterEmail("alice@nowhere.net");
+                try {
+                    signup.enterEmail("alice@nowhere.net");
+                } catch (ElementNotFoundException x) {
+                    // mailer plugin not installed, fine
+                }
                 signup.submit(r.j);
                 User alice = User.get("alice", false, Collections.emptyMap());
                 Assert.assertNotNull(alice);


### PR DESCRIPTION
In https://github.com/jenkinsci/bom/pull/359 the test from #23 fails when `jth.jenkins-war.path` is set to the megawar. Seems that `SignupPage.submit` quietly returns even when the signup in fact fails. Trying the page interactively showed that it would refuse to proceed unless you entered an email address. Making this change makes the test pass when `jth.jenkins-war.path` is set. The test utility predates the new signup page GUI but it is not clear that is relevant; I have not figured out what about the megawar (bundled JavaScript?) would change behavior here.
