### PR TITLE
[JENKINS-64661] Do not break global snippet generator

### DIFF
--- a/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.groovy
+++ b/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.groovy
@@ -10,7 +10,8 @@ def st = namespace("jelly:stapler")
 f.optionalBlock(name: 'useProjectSecurity', checked: instance != null, title: _("Enable project-based security")) {
     f.nested {
         c.blockWrapper {
-            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(my.class), field: 'inheritanceStrategy')
+            // It is unclear whether we can expect every Item to be an AbstractItem. While I've been unsuccessful finding one in a quick search, better be safe here and just offer fewer options if necessary.
+            f.dropdownDescriptorSelector(title: _("Inheritance Strategy"), descriptors: InheritanceStrategyDescriptor.getApplicableDescriptors(my?.class?:hudson.model.Item.class), field: 'inheritanceStrategy')
             st.include(class: "hudson.security.GlobalMatrixAuthorizationStrategy", page: "config")
         }
     }


### PR DESCRIPTION
[JENKINS-64661](https://issues.jenkins.io/browse/JENKINS-64661)

While the corresponding `NodeProperty` was updated to handle `null` `it`/`my` as that is part of the regular UI flow (#38), that was not done for this implementation as it's fairly unusual: It seems only the global (outside any context) snippet generator of `workflow-cps` calls this in that way, and additionally has no robustness when a particular implementation cannot handle that.