### PR TITLE
Add HTTP verb annotations to all web methods

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -56,6 +56,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -171,6 +172,7 @@ public class AuthorizationMatrixProperty extends AbstractFolderProperty<Abstract
         }
 
         @GET
+        @POST
         public FormValidation doCheckName(@AncestorInPath AbstractFolder<?> folder, @QueryParameter String value) {
             return doCheckName_(value, folder, Item.CONFIGURE);
         }

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -69,6 +69,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
 
 /**
  * {@link JobProperty} to associate ACL for each project.
@@ -189,6 +190,7 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>> implemen
         }
 
         @GET
+        @POST
         public FormValidation doCheckName(@AncestorInPath Job<?, ?> project, @QueryParameter String value) {
             return doCheckName_(value, project, Item.CONFIGURE);
         }

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -42,6 +42,8 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -224,6 +226,8 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy imp
         }
 
         @Restricted(NoExternalUse.class)
+        @GET
+        @POST
         public FormValidation doCheckName(@QueryParameter String value ) {
             return doCheckName_(value, Jenkins.get(), Jenkins.ADMINISTER);
         }

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainerDescriptor.java
@@ -19,6 +19,8 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
 import org.springframework.dao.DataAccessException;
 
 import javax.annotation.Nonnull;
@@ -122,6 +124,8 @@ public interface AuthorizationContainerDescriptor<T extends AuthorizationContain
 
     // Not used directly by Stapler due to the trailing _ (this prevented method confusion around 1.415).
     @Restricted(NoExternalUse.class)
+    @GET
+    @POST
     default FormValidation doCheckName_(@Nonnull String value, @Nonnull AccessControlled subject, @Nonnull Permission permission) {
 
         final String v = value.substring(1,value.length()-1);

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -49,6 +49,8 @@ import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -194,6 +196,8 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node> implemen
         }
 
         @Restricted(DoNotUse.class)
+        @GET
+        @POST
         public FormValidation doCheckName(@AncestorInPath Computer computer, @QueryParameter String value) {
             // Computer isn't a DescriptorByNameOwner before Jenkins 2.78, and then @AncestorInPath doesn't work
             return doCheckName_(value,


### PR DESCRIPTION
Essentially an experiment, but should work just fine.

Getting explicit verb annotations even without https://github.com/stapler/stapler/pull/205