### PR TITLE
Migrate from RestartableJenkinsRule to JenkinsSessionRule

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/PermissionAdderTest.java
@@ -15,24 +15,22 @@ import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 public class PermissionAdderTest {
 
     @Rule
-    public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
     @Test
     @Issue("JENKINS-20520")
-    public void ensureSavingAfterInitialUser() {
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                r.j.jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(true, false, null));
-                r.j.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
-                r.j.jenkins.save();
+    public void ensureSavingAfterInitialUser() throws Throwable {
+        sessions.then(j -> {
+                j.jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(true, false, null));
+                j.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
+                j.jenkins.save();
 
-                JenkinsRule.WebClient wc = r.j.createWebClient();
+                JenkinsRule.WebClient wc = j.createWebClient();
                 SignupPage signup = new SignupPage(wc.goTo("signup"));
                 signup.enterUsername("alice");
                 signup.enterPassword("alice");
@@ -42,17 +40,13 @@ public class PermissionAdderTest {
                 } catch (ElementNotFoundException x) {
                     // mailer plugin not installed, fine
                 }
-                signup.submit(r.j);
+                signup.submit(j);
                 User alice = User.get("alice", false, Collections.emptyMap());
                 Assert.assertNotNull(alice);
-                Assert.assertTrue(r.j.jenkins.getACL().hasPermission(alice.impersonate(), Jenkins.ADMINISTER));
-            }
+                Assert.assertTrue(j.jenkins.getACL().hasPermission(alice.impersonate(), Jenkins.ADMINISTER));
         });
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                Assert.assertTrue(r.j.jenkins.getACL().hasPermission(User.get("alice", false, Collections.emptyMap()).impersonate(), Jenkins.ADMINISTER));
-            }
+        sessions.then(j -> {
+                Assert.assertTrue(j.jenkins.getACL().hasPermission(User.get("alice", false, Collections.emptyMap()).impersonate(), Jenkins.ADMINISTER));
         });
     }
 }


### PR DESCRIPTION
We seem to be generally preferring `JenkinsSessionRule` to `RestartableJenkinsRule`. The main benefit to `JenkinsSessionRule` is that `#then` runs immediately, so it plays nicely with things like `@After.`