### PR TITLE
[JENKINS-66170] Apply table style when read-only

### DIFF
--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -181,7 +181,7 @@ THE SOFTWARE.
        </td></tr>
        <f:helpArea />
       </table>
-      <st:adjunct includes="hudson.security.table"/>
     </local:isEditable>
+    <st:adjunct includes="hudson.security.table"/>
   </f:block>
 </j:jelly>

--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -106,7 +106,7 @@ THE SOFTWARE.
       </d:tag>
     </d:taglib>
     <j:set var="strategyid" value="${descriptor.jsonSafeClassName}" />
-    <table id="${strategyid}" class="center-align global-matrix-authorization-strategy-table" name="data">
+    <table id="${strategyid}" class="center-align global-matrix-authorization-strategy-table ${readOnlyMode ? 'read-only' : ''}" name="data">
 
       <!-- The first row will show grouping -->
       <tr class="group-row">

--- a/src/main/resources/hudson/security/table.js
+++ b/src/main/resources/hudson/security/table.js
@@ -94,6 +94,11 @@ Behaviour.specify(".global-matrix-authorization-strategy-table TD.stop A.unselec
  * Whenever permission assignments change, this ensures that implied permissions get their checkboxes disabled.
  */
 Behaviour.specify(".global-matrix-authorization-strategy-table td input", 'GlobalMatrixAuthorizationStrategy', 0, function(e) {
+  var table = findAncestor(e, "TABLE");
+  if (table.hasClassName('read-only')) {
+    // if this is a read-only UI (ExtendedRead / SystemRead), do not enable checkboxes
+    return;
+  }
   var impliedByString = findAncestor(e, "TD").getAttribute('data-implied-by-list');
   var impliedByList = impliedByString.split(" ");
   var tr = findAncestor(e,"TR");


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-66170

This is a regression from #102 in which we moved to adjuncts, but since #82, JS was only available in read-write, and so the later change removed CSS from read-only.

@timja Could you PTAL if you have some time?