### PR TITLE
[JENKINS-67210] Fix linking to the global security realm

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritGlobalStrategy/config.properties
@@ -1,2 +1,2 @@
-blurb = This object will inherit the <a href="{0}/configureSecurity" target="_blank" rel="noopener noreferrer">global security settings</a> \
+blurb = This object will inherit the <a href="/configureSecurity/" target="_blank" rel="noopener noreferrer">global security settings</a> \
   directly, but not any permissions granted in ancestor items, if any.

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.properties
@@ -1,2 +1,2 @@
 blurb = This item will inherit its parent item's permissions (in addition to any permissions granted here). \
-        If this item is at the top level in Jenkins, it will inherit the <a href="{0}/configureSecurity" target="_blank" rel="noopener noreferrer">global security security settings</a>.
+        If this item is at the top level in Jenkins, it will inherit the <a href="/configureSecurity/" target="_blank" rel="noopener noreferrer">global security security settings</a>.

--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/NonInheritingStrategy/config.properties
@@ -1,4 +1,4 @@
-blurb = This object will <strong>not</strong> inherit the <a href="{0}/configureSecurity" target="_blank" rel="noopener noreferrer">global security settings</a>, or any permissions from its ancestors. \
+blurb = This object will <strong>not</strong> inherit the <a href="/configureSecurity/" target="_blank" rel="noopener noreferrer">global security settings</a>, or any permissions from its ancestors. \
   Only permissions explicitly enabled here will be granted. \
   To ensure that users are not inadvertently locked out from Jenkins, an exception is made for the <strong>Overall/Administer</strong> permission: \
   Administrators of Jenkins will still have access to this object even if not explicitly granted here.


### PR DESCRIPTION
The placeholder at the "Inherit permissions from parent ACL" tab is not resolved, so it would forward you to `localhost:8080/job/jobName/%7B0%7D/configureSecurity` instead of `localhost:8080/configureSecurity`.
Considering it's omitted in the other tabs, stripping it resolves named issue while maintaining a working way for the other tabs.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue