### PR TITLE
[JENKINS-67210] Fix broken link to global security configuration

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/inheritance/InheritParentStrategy/config.properties
@@ -1,2 +1,2 @@
-blurb = This item will inherit its parent item's permissions (in addition to any permissions granted here). \
+blurb = This item will inherit its parent item''s permissions (in addition to any permissions granted here). \
         If this item is at the top level in Jenkins, it will inherit the <a href="{0}/configureSecurity" target="_blank" rel="noopener noreferrer">global security security settings</a>.


### PR DESCRIPTION
Alternative to #105: Addresses the specific problem identified in [JENKINS-67210](https://issues.jenkins.io/browse/JENKINS-67210), while keeping compatibility with non-empty context paths.

CC @Kevin-CB