### PR TITLE
[JENKINS-67311] Fix help button for table

### DIFF
--- a/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -166,21 +166,14 @@ THE SOFTWARE.
       </tr>
     </table>
     <local:isEditable>
-      <table style="margin-top:0.5em; margin-left: 2em; width: 100%">
-       <tr>
-         <td colspan="3">
-            <input type="button" class="matrix-auth-add-user-button" value="${%Add user or group…}" id="${id}button"
-                   data-table-id="${id}"
-                   data-message-prompt="${%prompt}"
-                   data-message-empty="${%empty}"
-                   data-message-error="${%error}"
-            />
-         </td>
-         <td align="right">
-        <a href="#" class="help-button" helpURL="${rootURL}${descriptor.find('hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl').getHelpFile('user-group')}"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
-       </td></tr>
-       <f:helpArea />
-      </table>
+      <input type="button" class="matrix-auth-add-user-button" value="${%Add user or group…}" id="${id}button"
+             data-table-id="${id}"
+             data-message-prompt="${%prompt}"
+             data-message-empty="${%empty}"
+             data-message-error="${%error}"
+      />
+      <f:helpLink featureName="${%Permissions matrix}" url="${descriptor.find('hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl').getHelpFile('user-group')}"/>
+      <f:helpArea />
     </local:isEditable>
     <st:adjunct includes="hudson.security.table"/>
   </f:block>

--- a/src/main/resources/hudson/security/table.css
+++ b/src/main/resources/hudson/security/table.css
@@ -60,3 +60,6 @@
   border-bottom: 1px solid transparent;
   white-space: nowrap;
 }
+.matrix-auth-add-user-button {
+  margin: 10px;
+}


### PR DESCRIPTION
See [JENKINS-67311](https://issues.jenkins.io/browse/JENKINS-67311).

Some of the alignments are off in the old core baseline, and the margin has no effect, but I don't think I care enough to fix either. It works well enough, and the help text has problems anyway.

@timja FYI just in case, a tables to divs issue I think as this broke in 2.264.

### Screenshots

<details>
<summary>2.222.x</summary>

> <img width="1694" alt="old-global" src="https://user-images.githubusercontent.com/1831569/144931787-85aa80bd-4d8f-4a65-9fa3-afd1e11d99c9.png">
> <img width="1567" alt="old-job" src="https://user-images.githubusercontent.com/1831569/144931792-ddfedd17-3b73-4f0c-9496-5b7e369e7d13.png">
> <img width="2018" alt="old-agent" src="https://user-images.githubusercontent.com/1831569/144931799-5412a3f5-e3a9-4837-b178-9d62b3799eb5.png">

</details>


<details>
<summary>2.319.x</summary>

> <img width="2015" alt="new-global" src="https://user-images.githubusercontent.com/1831569/144931846-5a81e775-a92c-472b-b4a3-670c4f1564d3.png">
> <img width="1566" alt="new-job" src="https://user-images.githubusercontent.com/1831569/144931860-cfd9364e-21c6-4379-a90e-7ade76429aa5.png">
> <img width="2042" alt="new-agent" src="https://user-images.githubusercontent.com/1831569/144931877-03c46806-a7ce-498e-bf90-f4cf3a17d03d.png">

</details>