### PR TITLE
[JENKINS-67902] Fix tooltips not showing on checkboxes 

### DIFF
--- a/src/main/resources/hudson/security/table.js
+++ b/src/main/resources/hudson/security/table.js
@@ -180,7 +180,7 @@ Behaviour.specify(".global-matrix-authorization-strategy-table td input", 'Globa
   var impliedByList = impliedByString.split(" ");
   var tr = findAncestor(e,"TR");
   e.disabled = false;
-  e.setAttribute('tooltip', YAHOO.lang.escapeHTML(findAncestor(e, "TD").getAttribute('data-tooltip-enabled')));
+  e.nextSibling.setAttribute('tooltip', YAHOO.lang.escapeHTML(findAncestor(e, "TD").getAttribute('data-tooltip-enabled')));
 
   for (var i = 0; i < impliedByList.length; i++) {
     var permissionId = impliedByList[i];
@@ -188,7 +188,7 @@ Behaviour.specify(".global-matrix-authorization-strategy-table td input", 'Globa
     if (reference !== null) {
       if (reference.checked) {
         e.disabled = true;
-        e.setAttribute('tooltip', YAHOO.lang.escapeHTML(findAncestor(e, "TD").getAttribute('data-tooltip-disabled')));
+        e.nextSibling.setAttribute('tooltip', YAHOO.lang.escapeHTML(findAncestor(e, "TD").getAttribute('data-tooltip-disabled')));
       }
     }
   }


### PR DESCRIPTION
Relating to https://issues.jenkins.io/browse/JENKINS-67902.

The problem was was that in newer versions of Jenkins the checkbox `input` is invisible, meaning that there is no hitbox for the user to show the tooltip. The solution is to instead apply the tooltip to the `label`, which due to CSS shenanigans actually renders the checkbox and its hitbox.  

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
