### PR TITLE
[JENKINS-68922] Fix JS handling of 'Add user'/'Add group' buttons

### DIFF
--- a/src/main/resources/hudson/security/table.js
+++ b/src/main/resources/hudson/security/table.js
@@ -37,11 +37,13 @@ Behaviour.specify(".matrix-auth-add-button", 'GlobalMatrixAuthorizationStrategy'
         child.setAttribute("data-tooltip-disabled", child.getAttribute("data-tooltip-disabled").replace("__SID__", name).replace("__TYPE__", typeLabel));
       }
     }
-    findElementsBySelector(copy, ".stop img").each(function(item) {
-      item.setAttribute("title", item.getAttribute("title").replace("__SID__", name).replace("__TYPE__", typeLabel));
-    });
 
     var tooltipAttributeName = getTooltipAttributeName();
+
+    findElementsBySelector(copy, ".stop a").each(function(item) {
+      item.setAttribute("title", item.getAttribute("title").replace("__SID__", name).replace("__TYPE__", typeLabel));
+      item.setAttribute(tooltipAttributeName, item.getAttribute(tooltipAttributeName).replace("__SID__", name).replace("__TYPE__", typeLabel));
+    });
 
     findElementsBySelector(copy, "input[type=checkbox]").each(function(item) {
       const tooltip = item.getAttribute(tooltipAttributeName);


### PR DESCRIPTION
Fix [JENKINS-68922](https://issues.jenkins.io/browse/JENKINS-68922)

This still has a weakness in that we do not handle the "inactive" tooltip attribute, resulting in a DOM like

```
<a html-tooltip="Remove all permissions from __SID__" tooltip="Remove all permissions from theNewU" href="#" class="unselectall" title="Remove all permissions from theNewU"><img src="/jenkins/plugin/matrix-auth/images/unselect-all.svg" alt="Unselect all" width="16" height="16"></a>
```

This seems tolerable.