### PR TITLE
Declare config file provider test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>config-file-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
## Declare config file provider test dependency

Tests run successfully without this dependency when executed from the usual Apache Maven command line as in:

```
$ mvn clean verify
```

Tests fail when run in the BOM evaluation as in https://github.com/jenkinsci/bom/pull/1633 .  They report that a class from the config file provider plugin could not be found.

https://github.com/jenkinsci/bom/pull/1633#issuecomment-1346613743 provides details.

## Testing performed

Duplicated the problem by checking out https://github.com/jenkinsci/bom/pull/1633 and compiling the megawar in the bom directory with:

```
PLUGINS=matrix-auth TEST=InjectedTest bash local-test.sh
```

Then built the matrix-auth plugin with this command line

```
BOM_DIR=/home/mwaite/hub/core/bom
mvn -Denforcer.skip=true -Djenkins.version=2.381 -Djth.jenkins-war.path=$BOM_DIR/target/local-test/megawar.war \
-DoverrideWar=$BOM_DIR/target/local-test/megawar.war -DoverrideWarAdditions=true -DuseUpperBounds=true \
-DupperBoundsExcludes=javax.servlet:servlet-api \
-Dtest=ImportTest \
clean verify
```

That shows the failure in the matrix-auth 3.1.6 release.

Then modified the matrix-auth pom.xml file as noted in this commit and ran the same code again.  The test passed.

## Rationale

The additional test dependency does not modify the production code.  It will allow the next release of the matrix-auth plugin to be included in the Jenkins plugin bill of materials.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
