### PR TITLE
Upgrade Job DSL to 1.82

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.361.x</artifactId>
-                <version>1607.va_c1576527071</version>
+                <version>1887.vda_d0ddb_c15c4</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -86,15 +86,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.76</version>
+            <version>1.82</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- Diverged from core version of Groovy -->
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Job DSL no longer has a dependency on `groovy-all`.