### PR TITLE
Bump parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.52</version>
+        <version>4.60</version>
     </parent>
     <artifactId>matrix-auth</artifactId>
     <version>${revision}${changelist}</version>


### PR DESCRIPTION
Required for https://github.com/jenkinsci/jenkins/pull/7781 / https://github.com/jenkinsci/bom/pull/1968

Could I get a release please?

The parent pom bump includes https://github.com/jenkinsci/jenkins-test-harness/pull/567 which is released in https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.58