### PR TITLE
Wrap `<l:task/>` in `<l:tasks/>`

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/matrixauth/AmbiguityMonitor/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/matrixauth/AmbiguityMonitor/index.jelly
@@ -26,8 +26,10 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <l:layout title="${it.displayName}">
         <l:side-panel>
-            <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
-            <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" title="${%Manage Jenkins}"/>
+            <l:tasks>
+                <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
+                <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" title="${%Manage Jenkins}"/>
+            </l:tasks>
         </l:side-panel>
         <l:main-panel>
             <h1>${it.displayName}</h1>


### PR DESCRIPTION
Probably caused by a core change to the styles between 2.361.4 and 2.387.3, noticed while working with #147.

### Before

> <img width="558" alt="Screenshot 2023-07-17 at 10 38 07" src="https://github.com/jenkinsci/matrix-auth-plugin/assets/1831569/cddb53da-179c-4d8d-b16a-21d6891e056c">

### After

> <img width="557" alt="Screenshot 2023-07-17 at 10 37 53" src="https://github.com/jenkinsci/matrix-auth-plugin/assets/1831569/04c0f3f1-20f0-41bc-b358-080c0b5b1b3e">
