### PR TITLE
Remove outdated Jenkins version test conditional

### DIFF
--- a/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
+++ b/src/test/java/hudson/security/ProjectMatrixAuthorizationStrategyTest.java
@@ -8,7 +8,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.User;
-import hudson.util.VersionNumber;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -164,29 +163,17 @@ public class ProjectMatrixAuthorizationStrategyTest {
     private void configureGlobalMatrixAuthStrategyThroughUI(JenkinsRule.WebClient wc) throws Exception {
         HtmlForm form = wc.goTo("configureSecurity").getFormByName("config");
 
-        if (new VersionNumber("2.342").isOlderThanOrEqualTo(Jenkins.getVersion())) {
-            final Optional<HtmlElement> anyOption = form.getElementsByTagName("option").stream()
-                    .filter(option -> option.getTextContent()
-                            .contains(GlobalMatrixAuthorizationStrategy.DESCRIPTOR.getDisplayName()))
-                    .findAny();
+        final Optional<HtmlElement> anyOption = form.getElementsByTagName("option").stream()
+                .filter(option ->
+                        option.getTextContent().contains(GlobalMatrixAuthorizationStrategy.DESCRIPTOR.getDisplayName()))
+                .findAny();
 
-            if (!anyOption.isPresent()) {
-                throw new IllegalStateException("expected to find an option");
-            }
-            HtmlOption option = (HtmlOption) anyOption.get();
-            HtmlSelect parent = (HtmlSelect) option.getParentNode();
-            parent.setSelectedAttribute(option, true);
-        } else {
-            Optional<HtmlElement> anyLabel = form.getElementsByTagName("label").stream()
-                    .filter(lbl -> lbl.asNormalizedText()
-                            .contains(GlobalMatrixAuthorizationStrategy.DESCRIPTOR.getDisplayName()))
-                    .findAny();
-            if (!anyLabel.isPresent()) {
-                throw new IllegalStateException("expected to find a label");
-            }
-            HtmlElement label = anyLabel.get();
-            label.click();
+        if (!anyOption.isPresent()) {
+            throw new IllegalStateException("expected to find an option");
         }
+        HtmlOption option = (HtmlOption) anyOption.get();
+        HtmlSelect parent = (HtmlSelect) option.getParentNode();
+        parent.setSelectedAttribute(option, true);
         r.submit(form);
     }
 


### PR DESCRIPTION
## Remove Jenkins version conditional from test

Jenkins version must be at least 2.387.3 as defined in the pom.  No need for the test to check if the Jenkins version is older than 2.342, since it must be at least 2.387.3.

### Testing done

Automated tests pass with Java 11 on Linux

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
