### PR TITLE
Add support for Java 21 at compile time

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.2</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@ buildPlugin(useContainerAgent: true,
             configurations: [
                 [platform: 'linux', jdk: 11],
                 [platform: 'windows', jdk: 11],
-                [platform: 'linux', jdk: 17]
+                [platform: 'linux', jdk: 17],
+                [platform: 'linux', jdk: 21]
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.66</version>
+    <version>4.72</version>
   </parent>
   <artifactId>matrix-auth</artifactId>
   <version>${revision}${changelist}</version>
@@ -37,7 +37,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2230.v0cb_4040cde55</version>
+        <version>2329.v078520e55c19</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Merely consuming dependency updates shipping support for Java 21 at compile time.

This PR doesn't need to be released.

As a side effect, increase the configuration-as-code dependency from 1647 to 1670.