### PR TITLE
Remove outdated comments

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/matrixauth/ReadOnlyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/ReadOnlyTest.java
@@ -53,22 +53,14 @@ public class ReadOnlyTest {
         final HtmlPage page = initAndAssertPresent(configurationUrl);
         Assert.assertTrue(
                 "should contain add group/user button",
-                hasTagWithClassInPage(
-                        page,
-                        "button",
-                        "matrix-auth-add-button")); // Behavior.specify / makeButton converts input to button and wraps
-        // it in span
+                hasTagWithClassInPage(page, "button", "matrix-auth-add-button"));
     }
 
     private void assertPresentAndReadOnly(String configurationUrl) throws IOException, SAXException {
         final HtmlPage page = initAndAssertPresent(configurationUrl);
         Assert.assertFalse(
                 "should not contain add group/user button",
-                hasTagWithClassInPage(
-                        page,
-                        "button",
-                        "matrix-auth-add-button")); // Behavior.specify / makeButton converts input to button and wraps
-        // it in span
+                hasTagWithClassInPage(page, "button", "matrix-auth-add-button"));
     }
 
     @Before


### PR DESCRIPTION
This plugin no longer uses the YUI buttons, so mentioning them in a comment is misleading.
(The goal is just to clean up the search results for `makeButton` in the `jenkinsci` org)