### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.72</version>
+    <version>4.88</version>
   </parent>
   <artifactId>matrix-auth</artifactId>
   <version>${revision}${changelist}</version>
@@ -37,7 +37,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>3056.v53343b_a_b_a_850</version>
+        <version>3208.vb_21177d4b_cd9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>1.82</version>
+      <version>1.87</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Routine update of parent POM and BOM dependencies, as well as `job-dsl` (wasn't in BOM until recently).