### PR TITLE
Support "Microsoft Entra ID"-plugin by displaying readable group names.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/matrixauth/ValidationUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/ValidationUtil.java
@@ -31,6 +31,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
 import hudson.Util;
 import hudson.model.User;
+import hudson.security.GroupDetails;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException2;
 import hudson.util.FormValidation;
@@ -115,7 +116,8 @@ class ValidationUtil {
     static FormValidation validateGroup(String groupName, SecurityRealm sr, boolean ambiguous) {
         String escapedSid = Functions.escape(groupName);
         try {
-            sr.loadGroupByGroupname2(groupName, false);
+            GroupDetails details = sr.loadGroupByGroupname2(groupName, false);
+            escapedSid = Util.escape(StringUtils.abbreviate(details.getDisplayName(), 50));
             if (ambiguous) {
                 return FormValidation.respond(
                         FormValidation.Kind.WARNING,


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When using this plugin in combination with the "Microsoft Entra ID" plugin, users specified using an OID
will be shown with a readable name. However, groups do not get the same treatment and will always show an OID.  
This PR will solve that issue.  
It's a literal copy of a change made to the "role-strategy-plugin": https://github.com/jenkinsci/role-strategy-plugin/pull/355/files  
Jenkins issue: https://issues.jenkins.io/browse/JENKINS-75726  

Using OIDs is unfortunately the only way to make the Microsoft Entra ID plugin and this plugin work together. This PR will make this limitation less problematic.  
Also, only the matrix-auth-plugin supports inheritance of permissions in folders and jobs, which is essential for me.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
- I've tested this with the Entra ID plugin installed and the "Azure AD" authentication enabled. Before groups entered with a OID, will now show their Display Name instead.
- I've also tested it with Active Directory authentication enabled. For AD, OIDs are not supported, so you must specify the group using the Display Name and that name will be shown unchanged.
- I've repeated the previous test with the Entra ID plugin removed.

These tests have been done manually because I don't know how to add automated tests without having access to a real Entra ID system. I tested this at my workplace, where we do have this infrastructure.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md
You can override it by creating .github/pull_request_template.md in your own repository
-->