### PR TITLE
Wait a few seconds for test cleanup on Windows testWidgets

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/matrixauth/Security2180Test.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/Security2180Test.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.Functions;
 import hudson.model.Cause;
 import hudson.model.Executor;
 import hudson.model.FreeStyleBuild;
@@ -292,6 +293,10 @@ public class Security2180Test {
         final HtmlPage htmlPage = webClient.goTo("");
         final String contentAsString = htmlPage.getWebResponse().getContentAsString();
         assertThat(contentAsString, not(containsString("job/folder/job/job"))); // Fails while unfixed
+        if (Functions.isWindows()) {
+            // Wait a few seconds so that files are closed before test cleanup
+            Thread.sleep(3031);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Wait a few seconds for test cleanup on Windows testWidgets

The testWidgets() test fails consistently on ci.jenkins.io since the transition from Azure to AWS.  Since the tests are already using long sleep calls for various other purposes, let's sleep at the exit from the failing test so that there is time for Java to close files.

### Testing done

Confirmed that `mvn clean verify` passes on my Linux computer.  Confirmed on ci.jenkins.io that [Windows tests pass](https://ci.jenkins.io/job/Plugins/job/matrix-auth-plugin/job/PR-173/lastSuccessfulBuild/testReport/).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
