### PR TITLE
Wait before exiting testWidgets

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/matrixauth/Security2180Test.java
+++ b/src/test/java/org/jenkinsci/plugins/matrixauth/Security2180Test.java
@@ -294,8 +294,8 @@ public class Security2180Test {
         final String contentAsString = htmlPage.getWebResponse().getContentAsString();
         assertThat(contentAsString, not(containsString("job/folder/job/job"))); // Fails while unfixed
         if (Functions.isWindows()) {
-            // Wait a few seconds so that files are closed before test cleanup
-            Thread.sleep(3031);
+            // Wait several seconds so that files are closed before test cleanup
+            Thread.sleep(5000);
         }
     }
 


### PR DESCRIPTION
## Wait before exiting testWidgets

The `testWidgets` test has failed 2 out of 2 builds on the master branch since the transition of ci.jenkins.io from Azure to AWS.   Other plugins have seen similar behavior and have reduced the failures significantly by waiting several seconds at the end of the test before exiting the test.

Pull requests that have used that technique include:

* https://github.com/jenkinsci/config-file-provider-plugin/pull/381
* https://github.com/jenkinsci/dashboard-view-plugin/pull/417

A 3 second sleep was enough to pass 3 of 4 test runs in pull request:

* https://github.com/jenkinsci/matrix-auth-plugin/pull/173

### Testing done

Confirmed that the tests pass locally.  Confirmed that the tests pass on ci.jenkins.io 9 of 9 times.  Ready for review

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
