### PR TITLE
Prepare for Java 25 release Sep 16, 2025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.5</version>
+    <version>5.18</version>
   </parent>
   <artifactId>matrix-auth</artifactId>
   <version>${revision}${changelist}</version>

--- a/src/main/java/hudson/security/AuthorizationMatrixProperty.java
+++ b/src/main/java/hudson/security/AuthorizationMatrixProperty.java
@@ -24,7 +24,6 @@
 package hudson.security;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -223,9 +222,6 @@ public class AuthorizationMatrixProperty extends JobProperty<Job<?, ?>>
 
     private final class AclImpl extends SidACL {
         @CheckForNull
-        @SuppressFBWarnings(
-                value = "NP_BOOLEAN_RETURN_NULL",
-                justification = "As designed, implements a third state for the ternary logic")
         protected Boolean hasPermission(Sid sid, Permission p) {
             if (AuthorizationMatrixProperty.this.hasPermission(toString(sid), p, sid instanceof PrincipalSid)) {
                 return true;

--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -25,7 +25,6 @@ package hudson.security;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.PluginManager;
 import hudson.model.Descriptor;
@@ -114,9 +113,6 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy
 
     private final class AclImpl extends SidACL {
         @CheckForNull
-        @SuppressFBWarnings(
-                value = "NP_BOOLEAN_RETURN_NULL",
-                justification = "As designed, implements a third state for the ternary logic")
         protected Boolean hasPermission(Sid p, Permission permission) {
             if (GlobalMatrixAuthorizationStrategy.this.hasPermission(
                     toString(p), permission, p instanceof PrincipalSid)) return true;

--- a/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationMatrixNodeProperty.java
@@ -25,7 +25,6 @@ package org.jenkinsci.plugins.matrixauth;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Node;
@@ -116,9 +115,6 @@ public class AuthorizationMatrixNodeProperty extends NodeProperty<Node>
 
     private final class AclImpl extends SidACL {
         @CheckForNull
-        @SuppressFBWarnings(
-                value = "NP_BOOLEAN_RETURN_NULL",
-                justification = "As designed, implements a third state for the ternary logic")
         protected Boolean hasPermission(Sid sid, Permission p) {
             if (AuthorizationMatrixNodeProperty.this.hasPermission(toString(sid), p, sid instanceof PrincipalSid)) {
                 return true;


### PR DESCRIPTION
## Prepare for Java 25 release Sep 16, 2025

Java 25 is the next Java Long Term Support release.  It is scheduled to release Sep 16, 2025.  The Jenkins project intends to support new Java LTS releases soon after they are available.  The initial goal is to have Jenkins core and the top 200 plugins compiling and testing with Java 25 by Oct 31, 2025.

Without these changes, the plugin does not compile with Java 24.  Since we can expect that Java 25 will be a superset of Java 24, this update will help prepare the plugin to eventually be compiled and tested with Java 25.

The changes include:

* Update parent pom from 5.5 to 5.18 (most recent parent pom)
* Remove 3 spotbugs suppressions that are no longer necessary

### Testing done

Confirmed that `mvn clean verify` passes with the changes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
