### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    ignore:
+      # BOM and build dependencies are excluded, they are released far too often and matter too little
+      - dependency-name: "io.jenkins.tools.bom:bom-2.*.x"
+      - dependency-name: "io.jenkins.tools.incrementals:git-changelist-maven-extension"
+      - dependency-name: "org.jenkins-ci.plugins:plugin"


### PR DESCRIPTION
To be merged only after https://github.com/jenkinsci/matrix-auth-plugin/pull/180 so there's no unnecessary `job-dsl` PR.